### PR TITLE
stop encode special chars for full sanitizer

### DIFF
--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -28,7 +28,7 @@ module Rails
 
         Loofah.fragment(html).tap do |fragment|
           remove_xpaths(fragment, XPATHS_TO_REMOVE)
-        end.text
+        end.text(encode_special_chars: false)
       end
     end
 


### PR DESCRIPTION
Currently when we santize (using rails strip_tags helper for example) text it encode \r chars. For example

    ActionController::Base.helpers.strip_tags("test\r\n\r\ntest") #=> "test&#13;\n&#13;\ntest"

We should pass encode_special_chars: false to Loofah.fragment.text method to avoid it.

    Loofah.fragment("test\r\n\r\ntest").text(encode_special_chars: false) #=> "test\r\n\r\ntest"


Having text with encoded \r makes problems with transforming it using for example textile rails helper - it stop produce paragraphs. (Rails use RedCloth for it) example:

    RedCloth.new("test&#13;\n&#13;\ntest").to_html #=> "<p>test&#13;<br />\n&#13;<br />\ntest</p>"
    RedCloth.new("test\r\n\r\ntest").to_html #=> "<p>test</p>\n<p>test</p>"

By the way sanitize from Rails::Html::WhiteListSanitizer don't encode special chars :)

    ActionController::Base.helpers.sanitize("test\r\n\r\ntest") #=> "test\r\n\r\ntest"
