### PR TITLE
Allow ASCII-8BIT string for white list sanitize.

### DIFF
--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -106,7 +106,7 @@ module Rails
         return unless html
         return html if html.empty?
 
-        loofah_fragment = Loofah.fragment(html)
+        loofah_fragment = Loofah.fragment(html, pick_encoding(html))
 
         if scrubber = options[:scrubber]
           # No duck typing, Loofah ensures subclass of Loofah::Scrubber
@@ -135,6 +135,10 @@ module Rails
 
       def allowed_attributes(options)
         options[:attributes] || self.class.allowed_attributes
+      end
+
+      def pick_encoding(html)
+        'UTF-8' if html.encoding == Encoding::ASCII_8BIT # Nokogiri doesn't support ASCII-8BIT
       end
     end
   end

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -247,6 +247,11 @@ class SanitizersTest < Minitest::Test
     assert_equal text, white_list_sanitize(text, attributes: ['foo'])
   end
 
+  def test_should_allow_ascii_8bit_string
+    text = '1.0'.force_encoding('ASCII-8BIT')
+    assert_equal '1.0', white_list_sanitize(text)
+  end
+
   def test_scrub_style_if_style_attribute_option_is_passed
     input = '<p style="color: #000; background-image: url(http://www.ragingplatypus.com/i/cam-full.jpg);"></p>'
     assert_equal '<p style="color: #000;"></p>', white_list_sanitize(input, attributes: %w(style))


### PR DESCRIPTION
Fix this issue: https://github.com/rails/rails-html-sanitizer/issues/30

Also related to this issue: https://github.com/rails/rails/issues/18975