### PR TITLE
Prevent "unknown encoding: ASCII-8BIT" errors

### DIFF
--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -120,7 +120,7 @@ module Rails
           loofah_fragment.scrub!(:strip)
         end
 
-        loofah_fragment.to_s
+        properly_encode(loofah_fragment, encoding: 'UTF-8')
       end
 
       def sanitize_css(style_string)
@@ -135,6 +135,10 @@ module Rails
 
       def allowed_attributes(options)
         options[:attributes] || self.class.allowed_attributes
+      end
+
+      def properly_encode(fragment, options)
+        fragment.xml? ? fragment.to_xml(options) : fragment.to_html(options)
       end
     end
   end

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -441,6 +441,13 @@ class SanitizersTest < Minitest::Test
     assert_sanitized %(<a href="http&#x3A;//legit">), %(<a href="http://legit">)
   end
 
+  def test_sanitize_ascii_8bit_string
+    white_list_sanitize('<a>hello</a>'.encode('ASCII-8BIT')).tap do |sanitized|
+      assert_equal '<a>hello</a>', sanitized
+      assert_equal Encoding::UTF_8, sanitized.encoding
+    end
+  end
+
 protected
 
   def xpath_sanitize(input, options = {})


### PR DESCRIPTION
Fixes #30

Nokogiri would throw these errors when outputting the fragment with #to_s.
Instead call the format serializers directly and pass a UTF-8 encoding.

cc @rafaelfranca @kindjar @ncri @Junichilto