### PR TITLE
Pass options to the text method.

### DIFF
--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -28,7 +28,7 @@ module Rails
 
         Loofah.fragment(html).tap do |fragment|
           remove_xpaths(fragment, XPATHS_TO_REMOVE)
-        end.text
+        end.text(options)
       end
     end
 

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -104,6 +104,11 @@ class SanitizersTest < Minitest::Test
     assert_equal "Frozen string with no tags", full_sanitize("Frozen string with no tags".freeze)
   end
 
+  def test_full_sanitize_allows_turning_off_encoding_special_chars
+    assert_equal '&amp;', full_sanitize('&')
+    assert_equal '&', full_sanitize('&', encode_special_chars: false)
+  end
+
   def test_strip_links_with_tags_in_tags
     expected = "a href='hello'&gt;all <b>day</b> long/a&gt;"
     input = "<<a>a href='hello'>all <b>day</b> long<</A>/a>"


### PR DESCRIPTION
Fixes #31.

This lets us avoid encoding special chars twice in Rails as `strip_tags` could be written as:

```ruby
def strip_tags(html)
  self.class.full_sanitizer.sanitize(html, encode_special_chars: false) # let Rails handle escaping.
end
```

I didn't document this option as it's really for our internal use. But there's a potential security vector we have to take into account here.

Alternatively, I guess we could just call `html_safe` in `strip_tags`, but that makes me feel uneasy too.

cc @rafaelfranca