### PR TITLE
Refactor TargetScrubber

### DIFF
--- a/lib/rails/html/scrubbers.rb
+++ b/lib/rails/html/scrubbers.rb
@@ -137,11 +137,11 @@ module Rails
     # If set, attributes included will be removed.
     class TargetScrubber < PermitScrubber
       def allowed_node?(node)
-        !@tags.include?(node.name)
+        !super
       end
 
       def scrub_attribute?(name)
-        @attributes.include?(name)
+        !super
       end
     end
   end


### PR DESCRIPTION
TargetScrubber asts as reversal to PermitScrubber.
Two methods `allowed_node?` and `scrub_attribute?` is now
too much to know about implementaion of PermitScrubber.
It should simply reverse a result of parent method.