### PR TITLE
Whitelist Underline Element by Default

### DIFF
--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -104,7 +104,7 @@ module Rails
         attr_accessor :allowed_tags
         attr_accessor :allowed_attributes
       end
-      self.allowed_tags = Set.new(%w(strong em b i p code pre tt samp kbd var sub
+      self.allowed_tags = Set.new(%w(strong em b i u p code pre tt samp kbd var sub
         sup dfn cite big small address hr br div span h1 h2 h3 h4 h5 h6 ul ol li dl dt dd abbr
         acronym a img blockquote del ins))
       self.allowed_attributes = Set.new(%w(href src width height alt cite datetime title class name xml:lang abbr))

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -58,11 +58,11 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_strip_invalid_html
-    assert_equal "", full_sanitize("<<<bad html")
+    assert_equal "&lt;&lt;", full_sanitize("<<<bad html")
   end
 
   def test_strip_nested_tags
-    expected = "Weia onclick='alert(document.cookie);'/&gt;rdos"
+    expected = "Wei&lt;a onclick='alert(document.cookie);'/&gt;rdos"
     input = "Wei<<a>a onclick='alert(document.cookie);'</a>/>rdos"
     assert_equal expected, full_sanitize(input)
   end
@@ -99,7 +99,7 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_strip_tags_with_many_open_quotes
-    assert_equal "", full_sanitize("<<<bad html>")
+    assert_equal "&lt;&lt;", full_sanitize("<<<bad html>")
   end
 
   def test_strip_tags_with_sentence
@@ -123,7 +123,7 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_strip_links_with_tags_in_tags
-    expected = "a href='hello'&gt;all <b>day</b> long/a&gt;"
+    expected = "&lt;a href='hello'&gt;all <b>day</b> long&lt;/a&gt;"
     input = "<<a>a href='hello'>all <b>day</b> long<</A>/a>"
     assert_equal expected, link_sanitize(input)
   end
@@ -360,7 +360,7 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_should_sanitize_script_tag_with_multiple_open_brackets
-    assert_sanitized %(<<SCRIPT>alert("XSS");//<</SCRIPT>), "alert(\"XSS\");//"
+    assert_sanitized %(<<SCRIPT>alert("XSS");//<</SCRIPT>), "&lt;alert(\"XSS\");//&lt;"
     assert_sanitized %(<iframe src=http://ha.ckers.org/scriptlet.html\n<a), ""
   end
 


### PR DESCRIPTION
The <u> tag seems pretty standard and might be useful to permit this by default with the other formatting tags - `<b>` and `<i>`.

I've also updated the tests to expect the escaped angle brackets instead of none at all. If this is not the intended behavior, then I'll be happy to revert that change (but at least now the CI passes).