### PR TITLE
Add nokogiri -v to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 sudo: false
 cache: bundler
 before_install: gem update bundler --no-document
+script:
+  - bundle exec nokogiri -v
 rvm:
   - 1.9.3
   - 2.0.0


### PR DESCRIPTION
Hi,
I am using Fedora 24.
As I failed `rake test` in my local environment, let me send pull-request to see Travis CI test result.

```
$ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]

$ bundle -v
Bundler version 1.14.3

$ bundle install --path vendor/bundle

$ bundle list
Gems included by the bundle:
  * activesupport (5.0.1)
  * bundler (1.14.3)
  * concurrent-ruby (1.0.4)
  * i18n (0.8.0)
  * loofah (2.0.3)
  * mini_portile2 (2.1.0)
  * minitest (5.10.1)
  * nokogiri (1.7.0.1)
  * rails-dom-testing (2.0.2)
  * rails-html-sanitizer (1.0.3)
  * rake (12.0.0)
  * thread_safe (0.3.5)
  * tzinfo (1.2.2)

$ bundle exec rake test
/usr/local/ruby-2.4.0/bin/ruby -w -I"lib" -I"/home/jaruga/git/rails-html-sanitizer/vendor/bundle/ruby/2.4.0/gems/rake-12.0.0/lib" "/home/jaruga/git/rails-html-sanitizer/vendor/bundle/ruby/2.4.0/gems/rake-12.0.0/lib/rake/rake_test_loader.rb" "test/sanitizer_test.rb" "test/scrubbers_test.rb
...
  1) Failure:
SanitizersTest#test_strip_nested_tags [/home/jaruga/git/rails-html-sanitizer/test/sanitizer_test.rb:67]:
--- expected
+++ actual
@@ -1 +1 @@
-"Weia onclick='alert(document.cookie);'/&gt;rdos"
+"Wei&lt;a onclick='alert(document.cookie);'/&gt;rdos"



  2) Failure:
SanitizersTest#test_should_sanitize_script_tag_with_multiple_open_brackets [/home/jaruga/git/rails-html-sanitizer/test/sanitizer_test.rb:363]:
Expected: alert("XSS");//
Actual: &lt;alert("XSS");//&lt;


  3) Failure:
SanitizersTest#test_strip_tags_with_many_open_quotes [/home/jaruga/git/rails-html-sanitizer/test/sanitizer_test.rb:102]:
Expected: ""
  Actual: "&lt;&lt;"


  4) Failure:
SanitizersTest#test_strip_invalid_html [/home/jaruga/git/rails-html-sanitizer/test/sanitizer_test.rb:61]:
Expected: ""
  Actual: "&lt;&lt;"


  5) Failure:
SanitizersTest#test_strip_links_with_tags_in_tags [/home/jaruga/git/rails-html-sanitizer/test/sanitizer_test.rb:128]:
--- expected
+++ actual
@@ -1 +1 @@
-"a href='hello'&gt;all <b>day</b> long/a&gt;"
+"&lt;a href='hello'&gt;all <b>day</b> long&lt;/a&gt;"


301 runs, 317 assertions, 5 failures, 0 errors, 0 skips
...

$ bundle exec vendor/bundle/ruby/2.4.0/bin/nokogiri -v
# Nokogiri (1.7.0.1)
    ---
    warnings: []
    nokogiri: 1.7.0.1
    ruby:
      version: 2.4.0
      platform: x86_64-linux
      description: ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-linux]
      engine: ruby
    libxml:
      binding: extension
      source: packaged
      libxml2_path: "/home/jaruga/git/rails-html-sanitizer/vendor/bundle/ruby/2.4.0/gems/nokogiri-1.7.0.1/ports/x86_64-pc-linux-gnu/libxml2/2.9.4"
      libxslt_path: "/home/jaruga/git/rails-html-sanitizer/vendor/bundle/ruby/2.4.0/gems/nokogiri-1.7.0.1/ports/x86_64-pc-linux-gnu/libxslt/1.1.29"
      libxml2_patches: []
      libxslt_patches: []
      compiled: 2.9.4
      loaded: 2.9.4

$ rpm -q zlib-devel
zlib-devel-1.2.8-10.fc24.x86_64
```




```