### PR TITLE
Fix / improve tests

### DIFF
--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -74,7 +74,7 @@ class SanitizersTest < Minitest::Test
     assert_equal expected, full_sanitize(input)
   end
 
-  def test_strip_comments
+  def test_remove_unclosed_tags
     assert_equal "This is ", full_sanitize("This is <-- not\n a comment here.")
   end
 

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -58,11 +58,11 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_strip_invalid_html
-    assert_equal "", full_sanitize("<<<bad html")
+    assert_equal "&lt;&lt;", full_sanitize("<<<bad html")
   end
 
   def test_strip_nested_tags
-    expected = "Weia onclick='alert(document.cookie);'/&gt;rdos"
+    expected = "Wei&lt;a onclick='alert(document.cookie);'/&gt;rdos"
     input = "Wei<<a>a onclick='alert(document.cookie);'</a>/>rdos"
     assert_equal expected, full_sanitize(input)
   end
@@ -98,8 +98,8 @@ class SanitizersTest < Minitest::Test
     assert_equal "This is a test.", full_sanitize("<p>This <u>is<u> a <a href='test.html'><strong>test</strong></a>.</p>")
   end
 
-  def test_strip_tags_with_many_open_quotes
-    assert_equal "", full_sanitize("<<<bad html>")
+  def test_escape_tags_with_many_open_quotes
+    assert_equal "&lt;&lt;", full_sanitize("<<<bad html>")
   end
 
   def test_strip_tags_with_sentence
@@ -123,7 +123,7 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_strip_links_with_tags_in_tags
-    expected = "a href='hello'&gt;all <b>day</b> long/a&gt;"
+    expected = "&lt;a href='hello'&gt;all <b>day</b> long&lt;/a&gt;"
     input = "<<a>a href='hello'>all <b>day</b> long<</A>/a>"
     assert_equal expected, link_sanitize(input)
   end
@@ -360,7 +360,7 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_should_sanitize_script_tag_with_multiple_open_brackets
-    assert_sanitized %(<<SCRIPT>alert("XSS");//<</SCRIPT>), "alert(\"XSS\");//"
+    assert_sanitized %(<<SCRIPT>alert("XSS");//<</SCRIPT>), "&lt;alert(\"XSS\");//&lt;"
     assert_sanitized %(<iframe src=http://ha.ckers.org/scriptlet.html\n<a), ""
   end
 

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -87,7 +87,9 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_strip_blank_string
-    [nil, '', '   '].each { |blank| assert_equal blank, full_sanitize(blank) }
+    assert_nil full_sanitize(nil)
+    assert_equal "", full_sanitize("")
+    assert_equal "   ", full_sanitize("   ")
   end
 
   def test_strip_tags_with_plaintext


### PR DESCRIPTION
Hi,
I addressed #65 and noticed that some tests are failing. The tests fail because nokogiri behavior changed slightly. Tests still pass with 1.6.6.2, and fail at least since 1.6.8.1 (I didn't check which exact nokogiri release changed this behavior because I think it doesn't matter.). What changed in Nokogiri was that multiple opening tags are no longer removed, but escaped. Example:

before:
```ruby
full_sanitize("<<<a>") # => ""
```

after:
```ruby
full_sanitize("<<<a>") # => "&lt;&lt;"
```

I adjusted the tests so they pass again.

Lastly, I fixed a deprecation warning from MiniTest.