### PR TITLE
Fix CVE - Bump loofah dependency

### DIFF
--- a/rails-html-sanitizer.gemspec
+++ b/rails-html-sanitizer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "loofah", "~> 2.2", ">= 2.2.2"
+  spec.add_dependency "loofah", "~> 2.2", ">= 2.2.3"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Fixes exploit CVE-2018-16468 - Loofah XSS Vulnerability

Issue: https://github.com/flavorjones/loofah/issues/154

Not sure if anything else is required in this PR.

I just thought it would be good to exclude the 2.2.2 version as was picked up by `bundler-audit` in one of our apps.