### PR TITLE
Update minimum Loofah dependency to 2.2.3

### DIFF
--- a/rails-html-sanitizer.gemspec
+++ b/rails-html-sanitizer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "loofah", "~> 2.2", ">= 2.2.2"
+  spec.add_dependency "loofah", "~> 2.2", ">= 2.2.3"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
In response to CVE-2018-16468: https://github.com/flavorjones/loofah/issues/154