### PR TITLE
Update nokogiri to 1.8.5 ~ CVE-2018-14404

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in html-sanitizer.gemspec
 gemspec
 
-gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
+gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.8"
 gem "activesupport", RUBY_VERSION < "2.2.2" ? "~> 4.2.0" : ">= 5"


### PR DESCRIPTION
Name: loofah
Version: 2.2.2
Advisory: CVE-2018-16468
Criticality: Unknown
URL: https://github.com/flavorjones/loofah/issues/154
Title: Loofah XSS Vulnerability
Solution: upgrade to >= 2.2.3

Name: nokogiri
Version: 1.8.4
Advisory: CVE-2018-14404
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/issues/1785
Title: Nokogiri gem, via libxml2, is affected by multiple vulnerabilities
Solution: upgrade to >= 1.8.5