### PR TITLE
Update Loofah to patch XSS vulnerability

### DIFF
--- a/rails-html-sanitizer.gemspec
+++ b/rails-html-sanitizer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "loofah", "~> 2.2", ">= 2.2.2"
+  spec.add_dependency "loofah", "~> 2.2.3"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
This pull request is opened for Loofah to be updated to the latest version, after the `CVE-2018-16468` vulnerability was opened and resolved. For more details on the vulnerability, please see the [Loofah Issue#154](https://github.com/flavorjones/loofah/issues/15).