### PR TITLE
Update Loofah for CVE-2018-16468

### DIFF
--- a/rails-html-sanitizer.gemspec
+++ b/rails-html-sanitizer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "loofah", "~> 2.2", ">= 2.2.2"
+  spec.add_dependency "loofah", "~> 2.2", ">= 2.2.3"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
According to https://github.com/flavorjones/loofah/issues/154 the change
is minimal, just removing the 'from' attribute from the HTML5 Loofah whitelist 
fixes the CVE, so I don't think there should be any change in this gem 
aside from this update.