### PR TITLE
Fix Nokogiri link in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Loofah is what underlies the sanitizers and scrubbers of rails-html-sanitizer.
 - [Loofah and Loofah Scrubbers](https://github.com/flavorjones/loofah)
 
 The `node` argument passed to some methods in a custom scrubber is an instance of `Nokogiri::XML::Node`.
-- [`Nokogiri::XML::Node`](http://nokogiri.org/Nokogiri/XML/Node.html)
+- [`Nokogiri::XML::Node`](https://nokogiri.org/rdoc/Nokogiri/XML/Node.html)
 - [Nokogiri](http://nokogiri.org)
 
 ## Contributing to Rails Html Sanitizers

--- a/lib/rails/html/scrubbers.rb
+++ b/lib/rails/html/scrubbers.rb
@@ -43,7 +43,7 @@ module Rails
     # end
     #
     # See the documentation for Nokogiri::XML::Node to understand what's possible
-    # with nodes: http://nokogiri.org/Nokogiri/XML/Node.html
+    # with nodes: https://nokogiri.org/rdoc/Nokogiri/XML/Node.html
     class PermitScrubber < Loofah::Scrubber
       attr_reader :tags, :attributes
 


### PR DESCRIPTION
The link to the Nokogiri Node class in the documentation is pointing to an ugly 404 page 😄 

This PR fixes the url to use the new one.