### PR TITLE
Migrate to SafeListSanitizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,22 +41,22 @@ link_sanitizer.sanitize('<a href="example.com">Only the link text will be kept.<
 # => Only the link text will be kept.
 ```
 
-#### WhiteListSanitizer
+#### SafeListSanitizer
 
 ```ruby
-white_list_sanitizer = Rails::Html::WhiteListSanitizer.new
+safe_list_sanitizer = Rails::Html::SafeListSanitizer.new
 
-# sanitize via an extensive white list of allowed elements
-white_list_sanitizer.sanitize(@article.body)
+# sanitize via an extensive safe list of allowed elements
+safe_list_sanitizer.sanitize(@article.body)
 
-# white list only the supplied tags and attributes
-white_list_sanitizer.sanitize(@article.body, tags: %w(table tr td), attributes: %w(id class style))
+# safe list only the supplied tags and attributes
+safe_list_sanitizer.sanitize(@article.body, tags: %w(table tr td), attributes: %w(id class style))
 
-# white list via a custom scrubber
-white_list_sanitizer.sanitize(@article.body, scrubber: ArticleScrubber.new)
+# safe list via a custom scrubber
+safe_list_sanitizer.sanitize(@article.body, scrubber: ArticleScrubber.new)
 
-# white list sanitizer can also sanitize css
-white_list_sanitizer.sanitize_css('background-color: #000;')
+# safe list sanitizer can also sanitize css
+safe_list_sanitizer.sanitize_css('background-color: #000;')
 ```
 
 ### Scrubbers

--- a/lib/rails-html-sanitizer.rb
+++ b/lib/rails-html-sanitizer.rb
@@ -15,8 +15,14 @@ module Rails
           Html::LinkSanitizer
         end
 
+        def safe_list_sanitizer
+          Html::SafeListSanitizer
+        end
+
         def white_list_sanitizer
-          Html::WhiteListSanitizer
+          ActiveSupport::Deprecation.warn "warning: white_list_sanitizer is" \
+          "deprecated, please use safe_list_sanitizer instead."
+          safe_list_sanitizer
         end
       end
     end
@@ -34,7 +40,7 @@ module ActionView
         #   end
         #
         def sanitized_allowed_tags=(tags)
-          sanitizer_vendor.white_list_sanitizer.allowed_tags = tags
+          sanitizer_vendor.safe_list_sanitizer.allowed_tags = tags
         end
 
         # Replaces the allowed HTML attributes for the +sanitize+ helper.
@@ -44,7 +50,7 @@ module ActionView
         #   end
         #
         def sanitized_allowed_attributes=(attributes)
-          sanitizer_vendor.white_list_sanitizer.allowed_attributes = attributes
+          sanitizer_vendor.safe_list_sanitizer.allowed_attributes = attributes
         end
 
         [:protocol_separator,

--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -57,8 +57,8 @@ module Rails
       end
     end
 
-    # === Rails::Html::WhiteListSanitizer
-    # Sanitizes html and css from an extensive white list (see link further down).
+    # === Rails::Html::SafeListSanitizer
+    # Sanitizes html and css from an extensive safe list (see link further down).
     #
     # === Whitespace
     # We can't make any guarantees about whitespace being kept or stripped.
@@ -72,34 +72,34 @@ module Rails
     # so automatically.
     #
     # === Options
-    # Sanitizes both html and css via the white lists found here:
+    # Sanitizes both html and css via the safe lists found here:
     # https://github.com/flavorjones/loofah/blob/master/lib/loofah/html5/whitelist.rb
     #
-    # WhiteListSanitizer also accepts options to configure
-    # the white list used when sanitizing html.
+    # SafeListSanitizer also accepts options to configure
+    # the safe list used when sanitizing html.
     # There's a class level option:
-    # Rails::Html::WhiteListSanitizer.allowed_tags = %w(table tr td)
-    # Rails::Html::WhiteListSanitizer.allowed_attributes = %w(id class style)
+    # Rails::Html::SafeListSanitizer.allowed_tags = %w(table tr td)
+    # Rails::Html::SafeListSanitizer.allowed_attributes = %w(id class style)
     #
     # Tags and attributes can also be passed to +sanitize+.
     # Passed options take precedence over the class level options.
     #
     # === Examples
-    # white_list_sanitizer = Rails::Html::WhiteListSanitizer.new
+    # safe_list_sanitizer = Rails::Html::SafeListSanitizer.new
     #
     # Sanitize css doesn't take options
-    # white_list_sanitizer.sanitize_css('background-color: #000;')
+    # safe_list_sanitizer.sanitize_css('background-color: #000;')
     #
-    # Default: sanitize via a extensive white list of allowed elements
-    # white_list_sanitizer.sanitize(@article.body)
+    # Default: sanitize via a extensive safe list of allowed elements
+    # safe_list_sanitizer.sanitize(@article.body)
     #
-    # White list via the supplied tags and attributes
-    # white_list_sanitizer.sanitize(@article.body, tags: %w(table tr td),
+    # Safe list via the supplied tags and attributes
+    # safe_list_sanitizer.sanitize(@article.body, tags: %w(table tr td),
     # attributes: %w(id class style))
     #
-    # White list via a custom scrubber
-    # white_list_sanitizer.sanitize(@article.body, scrubber: ArticleScrubber.new)
-    class WhiteListSanitizer < Sanitizer
+    # Safe list via a custom scrubber
+    # safe_list_sanitizer.sanitize(@article.body, scrubber: ArticleScrubber.new)
+    class SafeListSanitizer < Sanitizer
       class << self
         attr_accessor :allowed_tags
         attr_accessor :allowed_attributes
@@ -146,7 +146,12 @@ module Rails
 
       def allowed_attributes(options)
         options[:attributes] || self.class.allowed_attributes
-      end
+      end      
+    end
+
+    WhiteListSanitizer = SafeListSanitizer
+    if Object.respond_to?(:deprecate_constant)
+      deprecate_constant :WhiteListSanitizer
     end
   end
 end


### PR DESCRIPTION
Safelist is easier to understand and less offensive. Chose `SafeList` because a similar ongoing effort in loofah gem: https://github.com/flavorjones/loofah/pull/158.

<kbd>[View Updated README.md](https://github.com/rails/rails-html-sanitizer/blob/911899f569e8e906ab1ee1c5be00dece1bec2431/README.md#safelistsanitizer)</kbd>

## How to run the test

```
bundle exec rake
```

## Note

An attempt to fix the build in #90.

<details>
<summary>Original motivation rails/rails#33677, other community efforts examples</summary>

- https://github.com/rails/rails/pull/33681
- https://github.com/graphiti-api/graphiti/pull/10
- https://github.com/rails/rails/pull/33718
- https://github.com/ruby/psych/pull/378
- https://github.com/ruby/ruby/pull/2008
- https://github.com/ruby/ruby/pull/2009
- https://github.com/rubocop-hq/rubocop/pull/6464
- https://github.com/rubygems/rubygems/pull/2463
- https://github.com/dtao/safe_yaml/pull/93
- https://github.com/rack/rack/pull/1314
- https://github.com/rubocop-hq/rubocop/pull/6466
- https://github.com/rubocop-hq/rubocop/pull/6467
- https://github.com/rspec/rspec-core/pull/2576
- https://github.com/rspec/rspec-expectations/pull/1083
- https://github.com/rspec/rspec-mocks/pull/1246
- https://github.com/rspec/rspec-support/pull/356
- https://github.com/pry/pry/pull/1874
- https://github.com/pry/pry/pull/1875
</details>