### PR TITLE
Remove href from LinkSanitizer tags list

### DIFF
--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -48,7 +48,7 @@ module Rails
     class LinkSanitizer < Sanitizer
       def initialize
         @link_scrubber = TargetScrubber.new
-        @link_scrubber.tags = %w(a href)
+        @link_scrubber.tags = %w(a)
         @link_scrubber.attributes = %w(href)
       end
 
@@ -146,7 +146,7 @@ module Rails
 
       def allowed_attributes(options)
         options[:attributes] || self.class.allowed_attributes
-      end      
+      end
     end
 
     WhiteListSanitizer = SafeListSanitizer

--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -40,11 +40,12 @@ module Rails
     end
 
     # === Rails::Html::LinkSanitizer
-    # Removes a tags and href attributes leaving only the link text
+    # Removes +a+ tags and +href+ attributes leaving only the link text.
     #
-    # link_sanitizer = Rails::Html::LinkSanitizer.new
-    # link_sanitizer.sanitize('<a href="example.com">Only the link text will be kept.</a>')
-    # # => Only the link text will be kept.
+    #  link_sanitizer = Rails::Html::LinkSanitizer.new
+    #  link_sanitizer.sanitize('<a href="example.com">Only the link text will be kept.</a>')
+    #
+    #  => 'Only the link text will be kept.'
     class LinkSanitizer < Sanitizer
       def initialize
         @link_scrubber = TargetScrubber.new

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -154,10 +154,6 @@ class SanitizersTest < Minitest::Test
     assert_equal "Magic", link_sanitize("<a href='http://www.rubyonrails.com/'>Mag<a href='http://www.ruby-lang.org/'>ic")
   end
 
-  def test_strip_links_with_a_tag_in_href
-    assert_equal "FrrFox", link_sanitize("<href onlclick='steal()'>FrrFox</a></href>")
-  end
-
   def test_sanitize_form
     assert_sanitized "<form action=\"/foo/bar\" method=\"post\"><input></form>", ''
   end


### PR DESCRIPTION
- `href` is not an [HTML element (tag)](https://developer.mozilla.org/en-US/docs/Web/HTML/Element)
- Improved documentation

  <img width="795" alt="Screenshot 2019-05-10 15 17 18" src="https://user-images.githubusercontent.com/1000669/57506443-cd38f100-7336-11e9-9416-6ce4f7ad784d.png">
