### PR TITLE
Add target to default allowed attributes (SafeListSanitizer)

### DIFF
--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -108,7 +108,7 @@ module Rails
       self.allowed_tags = Set.new(%w(strong em b i p code pre tt samp kbd var sub
         sup dfn cite big small address hr br div span h1 h2 h3 h4 h5 h6 ul ol li dl dt dd abbr
         acronym a img blockquote del ins))
-      self.allowed_attributes = Set.new(%w(href src width height alt cite datetime title class name xml:lang abbr))
+      self.allowed_attributes = Set.new(%w(href target src width height alt cite datetime title class name xml:lang abbr))
 
       def initialize
         @permit_scrubber = PermitScrubber.new


### PR DESCRIPTION
Current default `SafeListSanitizer` behaviour is to sanitize away the `target` attribute on links.

This property would be difficult to abuse - the worst case scenario, one supposes, would be for an already-permitted link to open in a new tab or window, or a different frame, as opposed to opening in the full current container.

Consequentially, I'd like to propose the `target` attribute is added to the `allowed_attributes` for the sanitizer.