### PR TITLE
Deprecated warning text, missing space

### DIFF
--- a/lib/rails-html-sanitizer.rb
+++ b/lib/rails-html-sanitizer.rb
@@ -21,7 +21,7 @@ module Rails
 
         def white_list_sanitizer
           ActiveSupport::Deprecation.warn "warning: white_list_sanitizer is" \
-          "deprecated, please use safe_list_sanitizer instead."
+          " deprecated, please use safe_list_sanitizer instead."
           safe_list_sanitizer
         end
       end


### PR DESCRIPTION
Small fix with deprecated warning:

DEPRECATION WARNING: warning: white_list_sanitizer **isdeprecated** , should be 
DEPRECATION WARNING: warning: white_list_sanitizer **is deprecated** 