### PR TITLE
CI: Drop unused sudo: false Travis directive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: ruby
-sudo: false
 cache: bundler
 before_install: gem update bundler --no-document
 rvm:


### PR DESCRIPTION
See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration for more details