### PR TITLE
Match Loofah's API changes.

### DIFF
--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -74,7 +74,7 @@ module Rails
     #
     # === Options
     # Sanitizes both html and css via the safe lists found here:
-    # https://github.com/flavorjones/loofah/blob/master/lib/loofah/html5/whitelist.rb
+    # https://github.com/flavorjones/loofah/blob/master/lib/loofah/html5/safelist.rb
     #
     # SafeListSanitizer also accepts options to configure
     # the safe list used when sanitizing html.

--- a/lib/rails/html/scrubbers.rb
+++ b/lib/rails/html/scrubbers.rb
@@ -138,17 +138,17 @@ module Rails
                       attr_node.node_name
                     end
 
-        if Loofah::HTML5::WhiteList::ATTR_VAL_IS_URI.include?(attr_name)
+        if Loofah::HTML5::SafeList::ATTR_VAL_IS_URI.include?(attr_name)
           # this block lifted nearly verbatim from HTML5 sanitization
           val_unescaped = CGI.unescapeHTML(attr_node.value).gsub(Loofah::HTML5::Scrub::CONTROL_CHARACTERS,'').downcase
-          if val_unescaped =~ /^[a-z0-9][-+.a-z0-9]*:/ && ! Loofah::HTML5::WhiteList::ALLOWED_PROTOCOLS.include?(val_unescaped.split(Loofah::HTML5::WhiteList::PROTOCOL_SEPARATOR)[0])
+          if val_unescaped =~ /^[a-z0-9][-+.a-z0-9]*:/ && ! Loofah::HTML5::SafeList::ALLOWED_PROTOCOLS.include?(val_unescaped.split(Loofah::HTML5::SafeList::PROTOCOL_SEPARATOR)[0])
             attr_node.remove
           end
         end
-        if Loofah::HTML5::WhiteList::SVG_ATTR_VAL_ALLOWS_REF.include?(attr_name)
+        if Loofah::HTML5::SafeList::SVG_ATTR_VAL_ALLOWS_REF.include?(attr_name)
           attr_node.value = attr_node.value.gsub(/url\s*\(\s*[^#\s][^)]+?\)/m, ' ') if attr_node.value
         end
-        if Loofah::HTML5::WhiteList::SVG_ALLOW_LOCAL_HREF.include?(node.name) && attr_name == 'xlink:href' && attr_node.value =~ /^\s*[^#\s].*/m
+        if Loofah::HTML5::SafeList::SVG_ALLOW_LOCAL_HREF.include?(node.name) && attr_name == 'xlink:href' && attr_node.value =~ /^\s*[^#\s].*/m
           attr_node.remove
         end
 

--- a/rails-html-sanitizer.gemspec
+++ b/rails-html-sanitizer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   # NOTE: There's no need to update this dependency for Loofah CVEs
   # in minor releases when users can simply run `bundle update loofah`.
-  spec.add_dependency "loofah", "~> 2.2", ">= 2.2.2"
+  spec.add_dependency "loofah", "~> 2.3"
 
   spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -181,7 +181,7 @@ class SanitizersTest < Minitest::Test
     assert_sanitized raw, %{src="javascript:bang" <img width="5">foo</img>, <span>bar</span>}
   end
 
-  tags = Loofah::HTML5::WhiteList::ALLOWED_ELEMENTS - %w(script form)
+  tags = Loofah::HTML5::SafeList::ALLOWED_ELEMENTS - %w(script form)
   tags.each do |tag_name|
     define_method "test_should_allow_#{tag_name}_tag" do
       scope_allowed_tags(tags) do


### PR DESCRIPTION
Loofah revised constant names and deprecated the older constants. The resulting log noise galvanizes immediate action.

In the short term, this change removes log noise due to deprecated constants.

In long term, it's just to keep up.
