### PR TITLE
Added video and controls to the allowed tags and attributes of HTML sanitizer

### DIFF
--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -107,8 +107,8 @@ module Rails
       end
       self.allowed_tags = Set.new(%w(strong em b i p code pre tt samp kbd var sub
         sup dfn cite big small address hr br div span h1 h2 h3 h4 h5 h6 ul ol li dl dt dd abbr
-        acronym a img blockquote del ins))
-      self.allowed_attributes = Set.new(%w(href src width height alt cite datetime title class name xml:lang abbr))
+        acronym a img blockquote del ins video))
+      self.allowed_attributes = Set.new(%w(href src width height alt cite datetime title class name xml:lang abbr controls poster))
 
       def initialize
         @permit_scrubber = PermitScrubber.new

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -195,12 +195,14 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_video_poster_sanitization
-    scope_allowed_tags(%w(video)) do
-      scope_allowed_attributes %w(src poster) do
-        assert_sanitized %(<video src="videofile.ogg" autoplay  poster="posterimage.jpg"></video>), %(<video src="videofile.ogg" poster="posterimage.jpg"></video>)
-        assert_sanitized %(<video src="videofile.ogg" poster=javascript:alert(1)></video>), %(<video src="videofile.ogg"></video>)
-      end
+    scope_allowed_attributes %w(src poster) do
+      assert_sanitized %(<video src="videofile.ogg" autoplay  poster="posterimage.jpg"></video>), %(<video src="videofile.ogg" poster="posterimage.jpg"></video>)
+      assert_sanitized %(<video src="videofile.ogg" poster=javascript:alert(1)></video>), %(<video src="videofile.ogg"></video>)
     end
+  end
+
+  def test_should_allow_video
+    assert_sanitized %(<video src="videofile.ogg" controls></video>), %(<video src="videofile.ogg" controls></video>)
   end
 
   # RFC 3986, sec 4.2


### PR DESCRIPTION
This PR adds video and controls to the allowed_tags and allowed_attributes in the sanitizer. I came to the part when I was trying to add a custom video tag in the Action Text. Action Text uses this sanitizer and removes all the video tags added in the `_blob.html.erb`

Please do let me know if updates here is not valid. I'll try to open a discussion in Rails to find a solution for this and raise a patch for it. Thanks 