### PR TITLE
Fix failing test

### DIFF
--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -274,6 +274,16 @@ class SanitizersTest < Minitest::Test
     assert_equal '<p style="color:#000;"></p>', safe_list_sanitize(input, attributes: %w(style))
   end
 
+  def test_should_allow_safe_css_functions_when_style_attribute_option_is_passed
+    input = '<p style="background: linear-gradient(transparent 50%, #ffff66 50%)"></p>'
+    assert_equal '<p style="background:linear-gradient(transparent 50%, #ffff66 50%);"></p>', safe_list_sanitize(input, attributes: %w(style))
+  end
+
+  def test_should_not_allow_unsafe_css_functions_when_style_attribute_option_is_passed
+    input = '<p style="background: this-isnt-a-safe-css-function(transparent 50%, #ffff66 50%); color: #000;"></p>'
+    assert_equal '<p style="color:#000;"></p>', safe_list_sanitize(input, attributes: %w(style))
+  end
+
   def test_should_raise_argument_error_if_tags_is_not_enumerable
     assert_raises ArgumentError do
       safe_list_sanitize('<a>some html</a>', tags: 'foo')

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -271,7 +271,7 @@ class SanitizersTest < Minitest::Test
 
   def test_scrub_style_if_style_attribute_option_is_passed
     input = '<p style="color: #000; background-image: url(http://www.ragingplatypus.com/i/cam-full.jpg);"></p>'
-    assert_equal '<p style="color: #000;"></p>', safe_list_sanitize(input, attributes: %w(style))
+    assert_equal '<p style="color:#000;"></p>', safe_list_sanitize(input, attributes: %w(style))
   end
 
   def test_should_raise_argument_error_if_tags_is_not_enumerable


### PR DESCRIPTION
This change fixes one of the two failing tests. It seems like a somewhat undocumented change happened between Loofah 2.8.0 and 2.9.0, causing the output of scrubbed style attributes to look a bit different.

Additionally, it adds two tests to ensure the work being done here doesn't break the feature added in 2.9.0.

It's worth bringing up that there was a regression introduced in Loofah 2.9.0 and it [has been patched today](https://github.com/flavorjones/loofah/releases/tag/v2.9.1). That issue might pop up here as well.

```
# Commit messages for more context!
dbff002:
Fix failing unit test

One of the changes in released in Loofah 2.9.0 broke this test. I can't
tell if this was an intended or unintended side effect of the change to
support functions in shorthand CSS rule.

I'm not sure how well documented this change was, but Loofah's tests
were updated to reflect a different formatting in the commit that causes
this behavior. I think it's safe to say that stripping the whitespace
from rules like the one in this test is the expected behavior.

The test should be updated to reflect the new formatting.

bca8940:
Add regression test for CSS functions

Loofah 2.9.0 added support for "safe" CSS functions in shorthand CSS
properties, e.g. `background: rgba(255,0,0,0.3);`

Adding a couple of tests to ensure that functionality works in this gem
too makes sense.
```