### PR TITLE
fix css scrubbing tests

### DIFF
--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -414,7 +414,7 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_should_sanitize_div_background_image_unicode_encoded
-    raw = %(background-image:\0075\0072\006C\0028'\006a\0061\0076\0061\0073\0063\0072\0069\0070\0074\003a\0061\006c\0065\0072\0074\0028.1027\0058.1053\0053\0027\0029'\0029)
+    raw = %(background-image:\u0075\u0072\u006C\u0028'\u006a\u0061\u0076\u0061\u0073\u0063\u0072\u0069\u0070\u0074\u003a\u0061\u006c\u0065\u0072\u0074\u0028.1027\u0058.1053\u0053\u0027\u0029'\u0029)
     assert_equal '', sanitize_css(raw)
   end
 

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -414,7 +414,7 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_should_sanitize_div_background_image_unicode_encoded
-    raw = %(background-image:\u0075\u0072\u006C\u0028'\u006a\u0061\u0076\u0061\u0073\u0063\u0072\u0069\u0070\u0074\u003a\u0061\u006c\u0065\u0072\u0074\u0028.1027\u0058.1053\u0053\u0027\u0029'\u0029)
+    raw = %(background-image:\u0075\u0072\u006C\u0028\u0027\u006a\u0061\u0076\u0061\u0073\u0063\u0072\u0069\u0070\u0074\u003a\u0061\u006c\u0065\u0072\u0074\u0028\u0031\u0032\u0033\u0034\u0029\u0027\u0029)
     assert_equal '', sanitize_css(raw)
   end
 

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -271,7 +271,8 @@ class SanitizersTest < Minitest::Test
 
   def test_scrub_style_if_style_attribute_option_is_passed
     input = '<p style="color: #000; background-image: url(http://www.ragingplatypus.com/i/cam-full.jpg);"></p>'
-    assert_equal '<p style="color: #000;"></p>', safe_list_sanitize(input, attributes: %w(style))
+    actual = safe_list_sanitize(input, attributes: %w(style))
+    assert_includes(['<p style="color: #000;"></p>', '<p style="color:#000;"></p>'], actual)
   end
 
   def test_should_raise_argument_error_if_tags_is_not_enumerable


### PR DESCRIPTION
Closes #111.

Notably, this test:

```
def test_should_sanitize_div_background_image_unicode_encoded
  raw = %(background-image:\0075\0072\006C\0028'\006a\0061\0076\0061\0073\0063\0072\0069\0070\0074\003a\0061\006c\0065\0072\0074\0028.1027\0058.1053\0053\0027\0029'\0029)
  assert_equal '', sanitize_css(raw)
end
```

is incorrectly encoded and has been since 2007; and should never have passed with earlier versions of Loofah. The property value `background-image:52C8'a161332904a1c5248.10278.1053379'9` is garbage, but it's not potentially harmful garbage that needs to be scrubbed.

This test was originally taken from [OWASP's XSS cheat sheet](https://owasp.org/www-community/xss-filter-evasion-cheatsheet), or a related source, and exists in that doc as:

```html
<DIV STYLE="background-image:\0075\0072\006C\0028'\006a\0061\0076\0061\0073\0063\0072\0069\0070\0074\003a\0061\006c\0065\0072\0074\0028.1027\0058.1053\0053\0027\0029'\0029">
```

but you'll notice that `\00XX` isn't how Ruby encodes unicode strings. Ruby uses `\uXXXX`, so this test is an incorrect translation/encoding of the original intent.

In addition, that original source contains an additional error, which is that `.1027` and `.1053` should be `\u0027` and `\u0053`. Both errors are corrected in this PR.

A short history of how encoding and typographical errors have propagated through this test in `html5lib`, `loofah`, `rails`, and `rails-html-sanitizer` is at https://github.com/flavorjones/loofah/pull/205 for anyone who's interested.
