### PR TITLE
improve performance (slightly)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## next / unreleased
+
+* Slightly improve performance.
+
+  Assuming elements are more common than comments, make one less method call per node.
+
+  *Mike Dalessio*
+
 ## 1.4.1 / 2021-08-18
 
 * Fix regression in v1.4.0 that did not pass comment nodes to the scrubber.

--- a/lib/rails/html/scrubbers.rb
+++ b/lib/rails/html/scrubbers.rb
@@ -68,7 +68,7 @@ module Rails
         end
         return CONTINUE if skip_node?(node)
 
-        unless (node.comment? || node.element?) && keep_node?(node)
+        unless (node.element? || node.comment?) && keep_node?(node)
           return STOP if scrub_node(node) == STOP
         end
 


### PR DESCRIPTION
This PR will make one less method call per element in a document.

Also rewrite the test coverage for PIs and comments from ab16fa4 to test behavior and not implementation.
