### PR TITLE
ci: add coverage for system libxml2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,22 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake
 
+  cruby-nokogiri-system-libraries:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.1"
+      - name: Install nokogiri with system libraries
+        run: |
+          sudo apt install pkg-config libxml2-dev libxslt-dev
+          bundle config set force_ruby_platform true
+          bundle config build.nokogiri --enable-system-libraries
+          bundle install
+          bundle exec nokogiri -v
+      - run: bundle exec rake
+
   jruby:
     continue-on-error: true # nokogiri on jruby has different behavior
     strategy:

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -505,7 +505,13 @@ class SanitizersTest < Minitest::Test
 
     text = safe_list_sanitize(html)
 
-    assert_equal %{<a href=\"examp&lt;!--%22%20unsafeattr=foo()&gt;--&gt;le.com\">test</a>}, text
+    acceptable_results = [
+      # nokogiri w/vendored+patched libxml2
+      %{<a href="examp&lt;!--%22%20unsafeattr=foo()&gt;--&gt;le.com">test</a>},
+      # nokogiri w/ system libxml2
+      %{<a href="examp<!--%22%20unsafeattr=foo()>-->le.com">test</a>},
+    ]
+    assert_includes(acceptable_results, text)
   end
 
   def test_uri_escaping_of_src_attr_in_a_tag_in_safe_list_sanitizer
@@ -515,7 +521,13 @@ class SanitizersTest < Minitest::Test
 
     text = safe_list_sanitize(html)
 
-    assert_equal %{<a src=\"examp&lt;!--%22%20unsafeattr=foo()&gt;--&gt;le.com\">test</a>}, text
+    acceptable_results = [
+      # nokogiri w/vendored+patched libxml2
+      %{<a src="examp&lt;!--%22%20unsafeattr=foo()&gt;--&gt;le.com">test</a>},
+      # nokogiri w/system libxml2
+      %{<a src="examp<!--%22%20unsafeattr=foo()>-->le.com">test</a>},
+    ]
+    assert_includes(acceptable_results, text)
   end
 
   def test_uri_escaping_of_name_attr_in_a_tag_in_safe_list_sanitizer
@@ -525,7 +537,13 @@ class SanitizersTest < Minitest::Test
 
     text = safe_list_sanitize(html)
 
-    assert_equal %{<a name=\"examp&lt;!--%22%20unsafeattr=foo()&gt;--&gt;le.com\">test</a>}, text
+    acceptable_results = [
+      # nokogiri w/vendored+patched libxml2
+      %{<a name="examp&lt;!--%22%20unsafeattr=foo()&gt;--&gt;le.com">test</a>},
+      # nokogiri w/system libxml2
+      %{<a name="examp<!--%22%20unsafeattr=foo()>-->le.com">test</a>},
+    ]
+    assert_includes(acceptable_results, text)
   end
 
   def test_uri_escaping_of_name_action_in_a_tag_in_safe_list_sanitizer
@@ -535,7 +553,13 @@ class SanitizersTest < Minitest::Test
 
     text = safe_list_sanitize(html, attributes: ['action'])
 
-    assert_equal %{<a action=\"examp&lt;!--%22%20unsafeattr=foo()&gt;--&gt;le.com\">test</a>}, text
+    acceptable_results = [
+      # nokogiri w/vendored+patched libxml2
+      %{<a action="examp&lt;!--%22%20unsafeattr=foo()&gt;--&gt;le.com">test</a>},
+      # nokogiri w/system libxml2
+      %{<a action="examp<!--%22%20unsafeattr=foo()>-->le.com">test</a>},
+    ]
+    assert_includes(acceptable_results, text)
   end
 
   def test_exclude_node_type_processing_instructions


### PR DESCRIPTION
#125 reported test failures when running with Nokogiri using system (unpatched) libxml2. This PR updates the tests to accept either form of output (the tests in question are specifically checking for escaped quotes and not escaped `<` and `>` characters).

The Nokogiri patch that affects this behavior is

    nokogiri/patches/libxml2/0002-Update-entities-to-remove-handling-of-ssi.patch

which was introduced to avoid server-side-include vulnerabilities, see https://github.com/sparklemotion/nokogiri/commit/4852e43
