### PR TITLE
Add `prune` flag to PermitScrubber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## next / unreleased
+
+* `SafeListSanitizer`, `PermitScrubber`, and `TargetScrubber` now all support pruning of unsafe tags.
+
+  By default, unsafe tags are still stripped, but this behavior can be changed to prune the element
+  and its children from the document by passing `prune: true` to any of these classes' constructors.
+
+  *seyrian*
+
 ## 1.4.2 / 2021-08-23
 
 * Slightly improve performance.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ safe_list_sanitizer.sanitize(@article.body, scrubber: ArticleScrubber.new)
 
 # safe list sanitizer can also sanitize css
 safe_list_sanitizer.sanitize_css('background-color: #000;')
+
+# fully prune nodes from the tree instead of stripping tags and leaving inner content
+safe_list_sanitizer = Rails::Html::SafeListSanitizer.new(prune: true)
 ```
 
 ### Scrubbers
@@ -107,6 +110,24 @@ html_fragment.scrub!(scrubber)
 html_fragment.to_s # => "<a></a>"
 ```
 
+By default, inner content is left, but it can be removed as well.
+
+```ruby
+scrubber = Rails::Html::PermitScrubber.new
+scrubber.tags = ['a']
+
+html_fragment = Loofah.fragment('<a><span>text</span></a>')
+html_fragment.scrub!(scrubber)
+html_fragment.to_s # => "<a>text</a>"
+
+scrubber = Rails::Html::PermitScrubber.new(prune: true)
+scrubber.tags = ['a']
+
+html_fragment = Loofah.fragment('<a><span>text</span></a>')
+html_fragment.scrub!(scrubber)
+html_fragment.to_s # => "<a></a>"
+```
+
 #### `Rails::Html::TargetScrubber`
 
 Where `PermitScrubber` picks out tags and attributes to permit in sanitization,
@@ -124,6 +145,23 @@ html_fragment.scrub!(scrubber)
 html_fragment.to_s # => "<a></a>"
 ```
 
+Similarly to `PermitScrubber`, nodes can be fully pruned.
+
+```ruby
+scrubber = Rails::Html::TargetScrubber.new
+scrubber.tags = ['span']
+
+html_fragment = Loofah.fragment('<a><span>text</span></a>')
+html_fragment.scrub!(scrubber)
+html_fragment.to_s # => "<a>text</a>"
+
+scrubber = Rails::Html::TargetScrubber.new(prune: true)
+scrubber.tags = ['span']
+
+html_fragment = Loofah.fragment('<a><span>text</span></a>')
+html_fragment.scrub!(scrubber)
+html_fragment.to_s # => "<a></a>"
+```
 #### Custom Scrubbers
 
 You can also create custom scrubbers in your application if you want to.

--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -110,8 +110,8 @@ module Rails
         acronym a img blockquote del ins))
       self.allowed_attributes = Set.new(%w(href src width height alt cite datetime title class name xml:lang abbr))
 
-      def initialize
-        @permit_scrubber = PermitScrubber.new
+      def initialize(prune: false)
+        @permit_scrubber = PermitScrubber.new(prune: prune)
       end
 
       def sanitize(html, options = {})

--- a/lib/rails/html/scrubbers.rb
+++ b/lib/rails/html/scrubbers.rb
@@ -45,10 +45,11 @@ module Rails
     # See the documentation for +Nokogiri::XML::Node+ to understand what's possible
     # with nodes: https://nokogiri.org/rdoc/Nokogiri/XML/Node.html
     class PermitScrubber < Loofah::Scrubber
-      attr_reader :tags, :attributes
+      attr_reader :tags, :attributes, :prune
 
-      def initialize
-        @direction = :bottom_up
+      def initialize(prune: false)
+        @prune = prune
+        @direction = @prune ? :top_down : :bottom_up
         @tags, @attributes = nil, nil
       end
 
@@ -98,7 +99,7 @@ module Rails
       end
 
       def scrub_node(node)
-        node.before(node.children) # strip
+        node.before(node.children) unless prune # strip
         node.remove
       end
 

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -258,6 +258,12 @@ class SanitizersTest < Minitest::Test
     end
   end
 
+  def test_should_allow_prune
+    sanitizer = Rails::Html::SafeListSanitizer.new(prune: true)
+    text = '<u>leave me <b>now</b></u>'
+    assert_equal "<u>leave me </u>", sanitizer.sanitize(text, tags: %w(u))
+  end
+
   def test_should_allow_custom_tags
     text = "<u>foo</u>"
     assert_equal text, safe_list_sanitize(text, tags: %w(u))

--- a/test/scrubbers_test.rb
+++ b/test/scrubbers_test.rb
@@ -66,6 +66,13 @@ class PermitScrubberTest < ScrubberTest
     assert_scrubbed html, '<tag>leave me now</tag>'
   end
 
+  def test_prunes_tags
+    @scrubber = Rails::Html::PermitScrubber.new(prune: true)
+    @scrubber.tags = %w(tag)
+    html = '<tag>leave me <span>now</span></tag>'
+    assert_scrubbed html, '<tag>leave me </tag>'
+  end
+
   def test_leaves_comments_when_supplied_as_tag
     @scrubber.tags = %w(div comment)
     assert_scrubbed('<div>one</div><!-- two --><span>three</span>',
@@ -156,6 +163,13 @@ class TargetScrubberTest < ScrubberTest
     @scrubber.attributes = %w(remove)
     html = '<tag remove="" other=""></tag><a remove="" other=""></a>'
     assert_scrubbed html, '<a other=""></a>'
+  end
+
+  def test_prunes_tags
+    @scrubber = Rails::Html::TargetScrubber.new(prune: true)
+    @scrubber.tags = %w(span)
+    html = '<tag>leave me <span>now</span></tag>'
+    assert_scrubbed html, '<tag>leave me </tag>'
   end
 end
 


### PR DESCRIPTION
By default PermitScrubber leaves behind inner content when scrubbing a
node. Setting the `prune` flag will remove the node *and* its content.

Will document in README if this is acceptable.