### PR TITLE
update tests to support Loofah in HTML5 parsing mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,12 @@ jobs:
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
-      - run: bundle exec rake
+      - name: html5
+        run: bundle exec rake
+      - name: html4
+        run: bundle exec rake
+        env:
+          LOOFAH_HTML4_MODE: "t"
 
   cruby-nokogiri-system-libraries:
     runs-on: ubuntu-latest
@@ -44,7 +49,12 @@ jobs:
           bundle config build.nokogiri --enable-system-libraries
           bundle install
           bundle exec nokogiri -v
-      - run: bundle exec rake
+      - name: html5
+        run: bundle exec rake
+      - name: html4
+        run: bundle exec rake
+        env:
+          LOOFAH_HTML4_MODE: "t"
 
   jruby:
     continue-on-error: true # nokogiri on jruby has different behavior

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in html-sanitizer.gemspec
 gemspec
 
-gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
+gem "nokogiri", git: "https://github.com/sparklemotion/nokogiri" # main has subclassing fix
+gem "loofah", git: "https://github.com/flavorjones/loofah", branch: "flavorjones-default-to-html5-parsing"
 gem "activesupport", RUBY_VERSION < "2.2.2" ? "~> 4.2.0" : ">= 5"


### PR DESCRIPTION
https://github.com/flavorjones/loofah/pull/239 proposes to change Loofah's behavior to use the libgumbo HTML5 parser (`Nokogiri::HTML5`) instead of libxml2's HTML4 parser (`Nokogiri::HTML4`).

This branch updates the rails-html-sanitizer test suite to support either mode, and illustrates some of the typical changes in sanitized output.

I don't think any of the sanitization changes should be considered "breaking", and that's partly the point of this exercise -- to build confidence that swapping out Loofah's parser is not an unreasonable thing to do. But I'd love to hear from other folks.