### PR TITLE
use loofah attribute scrubber

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
 gem "activesupport", RUBY_VERSION < "2.2.2" ? "~> 4.2.0" : ">= 5"
+gem "loofah", git: "https://github.com/flavorjones/loofah", branch: "flavorjones-scrub-accepts-allowed-attribute-names"

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -515,6 +515,16 @@ class SanitizersTest < Minitest::Test
     assert_equal %(<a data-foo="foo">foo</a>), safe_list_sanitize(text, attributes: ['data-foo'])
   end
 
+  def test_sanitize_data_protocol
+    text = "- XSS\"><iframe src=\"data:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=\">- XSS\"><iframe src=\"data:application/vnd.wap.xhtml+xml;base64,PHg6c2NyaXB0IHhtbG5zOng9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGh0bWwiPmFsZXJ0KGRvY3VtZW50LmRvbWFpbik8L3g6c2NyaXB0Pg==\">"
+
+    scope_allowed_tags %w(iframe) do
+      scope_allowed_attributes %w(src) do
+        assert_equal %(- XSS\"&gt;<iframe>- XSS\"&gt;<iframe></iframe></iframe>), safe_list_sanitize(text)
+      end
+    end
+  end
+
   def test_uri_escaping_of_href_attr_in_a_tag_in_safe_list_sanitizer
     skip if RUBY_VERSION < "2.3"
 


### PR DESCRIPTION
@rafaelfranca After seeing #135 I got a little concerned about the drift between Loofah and the RHS attribute scrubber.

I posted a branch of Loofah that accepts an optional set of allowed attributes, and have modified RHS in this PR to use it. There are a few failures that I think we should discuss. (See thread below.)

