### PR TITLE
Introduce initial ruby version guard

### DIFF
--- a/rails-html-sanitizer.gemspec
+++ b/rails-html-sanitizer.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{This gem is responsible to sanitize HTML fragments in Rails applications.}
   spec.homepage      = "https://github.com/rails/rails-html-sanitizer"
   spec.license       = "MIT"
+  
+  spec.required_ruby_version = '>= 2.6'
 
   spec.metadata      = {
     "bug_tracker_uri"   => "https://github.com/rails/rails-html-sanitizer/issues",


### PR DESCRIPTION
This appears to be an issue from cucumber-rails testing.

EDIT: I haven't spent hours and hours triaging. But I did reproduce this error a couple of times at ruby < 2.6

See: https://github.com/cucumber/cucumber-rails/runs/6822054026?check_suite_focus=true#step:3:120

EDIT2: In between the time dependabot made the PR for us and us merging the PR (Approx 5 days duration), a new version was cut in this gem (Which had this diff - https://github.com/rails/rails-html-sanitizer/compare/v1.4.2...v1.4.3)