### PR TITLE
ci: pin system lib test to 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - run: bundle exec rake
 
   cruby-nokogiri-system-libraries:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
because the 22.04 has a version with 4fd69f3 but not e986d09 from 2.9.14 and that's causing leading `<` to be parsed differently.

i'd fix it better than this, but I think only 2.9.13 has this behavior.