### PR TITLE
Bump actions/checkout from 2 to 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         ruby: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "ruby-head", "truffleruby-head"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}
@@ -33,7 +33,7 @@ jobs:
   cruby-nokogiri-system-libraries:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.1"
@@ -54,7 +54,7 @@ jobs:
         ruby: ["jruby-9.2", "jruby-9.3", "jruby-head"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{matrix.ruby}}


### PR DESCRIPTION
Fix the following warnings.

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2