### PR TITLE
dev: Rails rubocop config, and drop support for ruby `< 2.5`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "ruby-head", "truffleruby-head"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "ruby-head", "truffleruby-head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["jruby-9.2", "jruby-9.3", "jruby-head"]
+        ruby: ["jruby-9.3", "jruby-9.4", "jruby-head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,345 @@
+require:
+  - rubocop-minitest
+  - rubocop-packaging
+  - rubocop-performance
+  - rubocop-rails
+
+AllCops:
+  TargetRubyVersion: 2.7
+  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
+  # to ignore them, so only the ones explicitly set in this file are enabled.
+  DisabledByDefault: true
+  SuggestExtensions: false
+  Exclude:
+    - '**/tmp/**/*'
+    - '**/templates/**/*'
+    - '**/vendor/**/*'
+    - 'actionpack/lib/action_dispatch/journey/parser.rb'
+    - 'actionmailbox/test/dummy/**/*'
+    - 'actiontext/test/dummy/**/*'
+    - '**/node_modules/**/*'
+
+Performance:
+  Exclude:
+    - '**/test/**/*'
+
+# Prefer assert_not over assert !
+Rails/AssertNot:
+  Include:
+    - '**/test/**/*'
+
+# Prefer assert_not_x over refute_x
+Rails/RefuteMethods:
+  Include:
+    - '**/test/**/*'
+
+Rails/IndexBy:
+  Enabled: true
+
+Rails/IndexWith:
+  Enabled: true
+
+# Prefer &&/|| over and/or.
+Style/AndOr:
+  Enabled: true
+
+# Align `when` with `case`.
+Layout/CaseIndentation:
+  Enabled: true
+
+Layout/ClosingHeredocIndentation:
+  Enabled: true
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: true
+
+# Align comments with method definitions.
+Layout/CommentIndentation:
+  Enabled: true
+
+Layout/ElseAlignment:
+  Enabled: true
+
+# Align `end` with the matching keyword or starting expression except for
+# assignments, where it should be aligned with the LHS.
+Layout/EndAlignment:
+  Enabled: true
+  EnforcedStyleAlignWith: variable
+  AutoCorrect: true
+
+Layout/EndOfLine:
+  Enabled: true
+
+Layout/EmptyLineAfterMagicComment:
+  Enabled: true
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+  EnforcedStyle: only_before
+
+Layout/EmptyLinesAroundBlockBody:
+  Enabled: true
+
+# In a regular class definition, no empty lines around the body.
+Layout/EmptyLinesAroundClassBody:
+  Enabled: true
+
+# In a regular method definition, no empty lines around the body.
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: true
+
+# In a regular module definition, no empty lines around the body.
+Layout/EmptyLinesAroundModuleBody:
+  Enabled: true
+
+# Use Ruby >= 1.9 syntax for hashes. Prefer { a: :b } over { :a => :b }.
+Style/HashSyntax:
+  Enabled: true
+
+# Method definitions after `private` or `protected` isolated calls need one
+# extra level of indentation.
+Layout/IndentationConsistency:
+  Enabled: true
+  EnforcedStyle: indented_internal_methods
+
+# Two spaces, no tabs (for indentation).
+Layout/IndentationWidth:
+  Enabled: true
+
+Layout/LeadingCommentSpace:
+  Enabled: true
+
+Layout/SpaceAfterColon:
+  Enabled: true
+
+Layout/SpaceAfterComma:
+  Enabled: true
+
+Layout/SpaceAfterSemicolon:
+  Enabled: true
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  Enabled: true
+
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
+Layout/SpaceAroundOperators:
+  Enabled: true
+
+Layout/SpaceBeforeComma:
+  Enabled: true
+
+Layout/SpaceBeforeComment:
+  Enabled: true
+
+Layout/SpaceBeforeFirstArg:
+  Enabled: true
+
+Style/DefWithParentheses:
+  Enabled: true
+
+# Defining a method with parameters needs parentheses.
+Style/MethodDefParentheses:
+  Enabled: true
+
+Style/ExplicitBlockArgument:
+  Enabled: true
+
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always
+  Exclude:
+    - 'actionview/test/**/*.builder'
+    - 'actionview/test/**/*.ruby'
+    - 'actionpack/test/**/*.builder'
+    - 'actionpack/test/**/*.ruby'
+    - 'activestorage/db/migrate/**/*.rb'
+    - 'activestorage/db/update_migrate/**/*.rb'
+    - 'actionmailbox/db/migrate/**/*.rb'
+    - 'actiontext/db/migrate/**/*.rb'
+
+Style/MapToHash:
+  Enabled: true
+
+Style/RedundantFreeze:
+  Enabled: true
+
+# Use `foo {}` not `foo{}`.
+Layout/SpaceBeforeBlockBraces:
+  Enabled: true
+
+# Use `foo { bar }` not `foo {bar}`.
+Layout/SpaceInsideBlockBraces:
+  Enabled: true
+  EnforcedStyleForEmptyBraces: space
+
+# Use `{ a: 1 }` not `{a:1}`.
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+# Check quotes usage according to lint rule below.
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
+# Detect hard tabs, no hard tabs.
+Layout/IndentationStyle:
+  Enabled: true
+
+# Empty lines should not have any spaces.
+Layout/TrailingEmptyLines:
+  Enabled: true
+
+# No trailing whitespace.
+Layout/TrailingWhitespace:
+  Enabled: true
+
+# Use quotes for string literals when they are enough.
+Style/RedundantPercentQ:
+  Enabled: true
+
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+
+Lint/DuplicateRequire:
+  Enabled: true
+
+Lint/DuplicateMagicComment:
+  Enabled: true
+
+Lint/DuplicateMethods:
+  Enabled: true
+
+Lint/ErbNewArguments:
+  Enabled: true
+
+Lint/EnsureReturn:
+  Enabled: true
+
+# Use my_method(my_arg) not my_method( my_arg ) or my_method my_arg.
+Lint/RequireParentheses:
+  Enabled: true
+
+Lint/RedundantStringCoercion:
+  Enabled: true
+
+Lint/UriEscapeUnescape:
+  Enabled: true
+
+Lint/UselessAssignment:
+  Enabled: true
+
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
+Style/EvalWithLocation:
+  Enabled: true
+  Exclude:
+    - '**/test/**/*'
+
+Style/ParenthesesAroundCondition:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/RedundantBegin:
+  Enabled: true
+
+Style/RedundantReturn:
+  Enabled: true
+  AllowMultipleReturnValues: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/Semicolon:
+  Enabled: true
+  AllowAsExpressionSeparator: true
+
+# Prefer Foo.method over Foo::method
+Style/ColonMethodCall:
+  Enabled: true
+
+Style/TrivialAccessors:
+  Enabled: true
+
+# Prefer a = b || c over a = b ? b : c
+Style/RedundantCondition:
+  Enabled: true
+
+Performance/BindCall:
+  Enabled: true
+
+Performance/FlatMap:
+  Enabled: true
+
+Performance/MapCompact:
+  Enabled: true
+
+Performance/SelectMap:
+  Enabled: true
+
+Performance/RedundantMerge:
+  Enabled: true
+
+Performance/StartWith:
+  Enabled: true
+
+Performance/EndWith:
+  Enabled: true
+
+Performance/RegexpMatch:
+  Enabled: true
+
+Performance/ReverseEach:
+  Enabled: true
+
+Performance/StringReplacement:
+  Enabled: true
+
+Performance/UnfreezeString:
+  Enabled: true
+
+Performance/DeletePrefix:
+  Enabled: true
+
+Performance/DeleteSuffix:
+  Enabled: true
+
+Performance/OpenStruct:
+  Enabled: true
+
+Performance/InefficientHashSearch:
+  Enabled: true
+
+Performance/ConstantRegexp:
+  Enabled: true
+
+Performance/RedundantStringChars:
+  Enabled: true
+
+Performance/StringInclude:
+  Enabled: true
+
+Minitest/AssertRaisesWithRegexpArgument:
+  Enabled: true
+
+Minitest/AssertWithExpectedArgument:
+  Enabled: true
+
+Minitest/SkipEnsure:
+  Enabled: true
+
+Minitest/UnreachableAssertion:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source 'https://rubygems.org'
+# frozen_string_literal: true
+
+source "https://rubygems.org"
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,19 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in html-sanitizer.gemspec
 gemspec
 
+gem "rake"
+gem "minitest"
+gem "rails-dom-testing"
+
+group :rubocop do
+  gem "rubocop", ">= 1.25.1", require: false
+  gem "rubocop-minitest", require: false
+  gem "rubocop-packaging", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+end
+
+# specify gem versions for old rubies
 gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
 gem "activesupport", RUBY_VERSION < "2.2.2" ? "~> 4.2.0" : ">= 5"

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 require "bundler/gem_tasks"
 require "rake/testtask"
 
 task default: :test
 Rake::TestTask.new do |t|
-  t.pattern = 'test/**/*_test.rb'
+  t.pattern = "test/**/*_test.rb"
   t.warning = true
   t.verbose = true
 end

--- a/lib/rails-html-sanitizer.rb
+++ b/lib/rails-html-sanitizer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails/html/sanitizer/version"
 require "loofah"
 require "rails/html/scrubbers"

--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Html
     XPATHS_TO_REMOVE = %w{.//script .//form comment()}
@@ -8,15 +10,14 @@ module Rails
       end
 
       private
+        def remove_xpaths(node, xpaths)
+          node.xpath(*xpaths).remove
+          node
+        end
 
-      def remove_xpaths(node, xpaths)
-        node.xpath(*xpaths).remove
-        node
-      end
-
-      def properly_encode(fragment, options)
-        fragment.xml? ? fragment.to_xml(options) : fragment.to_html(options)
-      end
+        def properly_encode(fragment, options)
+          fragment.xml? ? fragment.to_xml(options) : fragment.to_html(options)
+        end
     end
 
     # === Rails::Html::FullSanitizer
@@ -35,7 +36,7 @@ module Rails
         remove_xpaths(loofah_fragment, XPATHS_TO_REMOVE)
         loofah_fragment.scrub!(TextOnlyScrubber.new)
 
-        properly_encode(loofah_fragment, encoding: 'UTF-8')
+        properly_encode(loofah_fragment, encoding: "UTF-8")
       end
     end
 
@@ -132,7 +133,7 @@ module Rails
           loofah_fragment.scrub!(:strip)
         end
 
-        properly_encode(loofah_fragment, encoding: 'UTF-8')
+        properly_encode(loofah_fragment, encoding: "UTF-8")
       end
 
       def sanitize_css(style_string)
@@ -140,14 +141,13 @@ module Rails
       end
 
       private
+        def allowed_tags(options)
+          options[:tags] || self.class.allowed_tags
+        end
 
-      def allowed_tags(options)
-        options[:tags] || self.class.allowed_tags
-      end
-
-      def allowed_attributes(options)
-        options[:attributes] || self.class.allowed_attributes
-      end
+        def allowed_attributes(options)
+          options[:attributes] || self.class.allowed_attributes
+        end
     end
 
     WhiteListSanitizer = SafeListSanitizer

--- a/lib/rails/html/sanitizer/version.rb
+++ b/lib/rails/html/sanitizer/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Html
     class Sanitizer

--- a/lib/rails/html/scrubbers.rb
+++ b/lib/rails/html/scrubbers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Rails
   module Html
     # === Rails::Html::PermitScrubber
@@ -77,84 +79,83 @@ module Rails
       end
 
       protected
-
-      def allowed_node?(node)
-        @tags.include?(node.name)
-      end
-
-      def skip_node?(node)
-        node.text?
-      end
-
-      def scrub_attribute?(name)
-        !@attributes.include?(name)
-      end
-
-      def keep_node?(node)
-        if @tags
-          allowed_node?(node)
-        else
-          Loofah::HTML5::Scrub.allowed_element?(node.name)
+        def allowed_node?(node)
+          @tags.include?(node.name)
         end
-      end
 
-      def scrub_node(node)
-        node.before(node.children) unless prune # strip
-        node.remove
-      end
+        def skip_node?(node)
+          node.text?
+        end
 
-      def scrub_attributes(node)
-        if @attributes
-          node.attribute_nodes.each do |attr|
-            attr.remove if scrub_attribute?(attr.name)
-            scrub_attribute(node, attr)
+        def scrub_attribute?(name)
+          !@attributes.include?(name)
+        end
+
+        def keep_node?(node)
+          if @tags
+            allowed_node?(node)
+          else
+            Loofah::HTML5::Scrub.allowed_element?(node.name)
+          end
+        end
+
+        def scrub_node(node)
+          node.before(node.children) unless prune # strip
+          node.remove
+        end
+
+        def scrub_attributes(node)
+          if @attributes
+            node.attribute_nodes.each do |attr|
+              attr.remove if scrub_attribute?(attr.name)
+              scrub_attribute(node, attr)
+            end
+
+            scrub_css_attribute(node)
+          else
+            Loofah::HTML5::Scrub.scrub_attributes(node)
+          end
+        end
+
+        def scrub_css_attribute(node)
+          if Loofah::HTML5::Scrub.respond_to?(:scrub_css_attribute)
+            Loofah::HTML5::Scrub.scrub_css_attribute(node)
+          else
+            style = node.attributes["style"]
+            style.value = Loofah::HTML5::Scrub.scrub_css(style.value) if style
+          end
+        end
+
+        def validate!(var, name)
+          if var && !var.is_a?(Enumerable)
+            raise ArgumentError, "You should pass :#{name} as an Enumerable"
+          end
+          var
+        end
+
+        def scrub_attribute(node, attr_node)
+          attr_name = if attr_node.namespace
+            "#{attr_node.namespace.prefix}:#{attr_node.node_name}"
+          else
+            attr_node.node_name
           end
 
-          scrub_css_attribute(node)
-        else
-          Loofah::HTML5::Scrub.scrub_attributes(node)
+          if Loofah::HTML5::SafeList::ATTR_VAL_IS_URI.include?(attr_name)
+            return if Loofah::HTML5::Scrub.scrub_uri_attribute(attr_node)
+          end
+
+          if Loofah::HTML5::SafeList::SVG_ATTR_VAL_ALLOWS_REF.include?(attr_name)
+            Loofah::HTML5::Scrub.scrub_attribute_that_allows_local_ref(attr_node)
+          end
+
+          if Loofah::HTML5::SafeList::SVG_ALLOW_LOCAL_HREF.include?(node.name) && attr_name == "xlink:href" && attr_node.value =~ /^\s*[^#\s].*/m
+            attr_node.remove
+          end
+
+          node.remove_attribute(attr_node.name) if attr_name == "src" && attr_node.value !~ /[^[:space:]]/
+
+          Loofah::HTML5::Scrub.force_correct_attribute_escaping! node
         end
-      end
-
-      def scrub_css_attribute(node)
-        if Loofah::HTML5::Scrub.respond_to?(:scrub_css_attribute)
-          Loofah::HTML5::Scrub.scrub_css_attribute(node)
-        else
-          style = node.attributes['style']
-          style.value = Loofah::HTML5::Scrub.scrub_css(style.value) if style
-        end
-      end
-
-      def validate!(var, name)
-        if var && !var.is_a?(Enumerable)
-          raise ArgumentError, "You should pass :#{name} as an Enumerable"
-        end
-        var
-      end
-
-      def scrub_attribute(node, attr_node)
-        attr_name = if attr_node.namespace
-                      "#{attr_node.namespace.prefix}:#{attr_node.node_name}"
-                    else
-                      attr_node.node_name
-                    end
-
-        if Loofah::HTML5::SafeList::ATTR_VAL_IS_URI.include?(attr_name)
-          return if Loofah::HTML5::Scrub.scrub_uri_attribute(attr_node)
-        end
-
-        if Loofah::HTML5::SafeList::SVG_ATTR_VAL_ALLOWS_REF.include?(attr_name)
-          Loofah::HTML5::Scrub.scrub_attribute_that_allows_local_ref(attr_node)
-        end
-
-        if Loofah::HTML5::SafeList::SVG_ALLOW_LOCAL_HREF.include?(node.name) && attr_name == 'xlink:href' && attr_node.value =~ /^\s*[^#\s].*/m
-          attr_node.remove
-        end
-
-        node.remove_attribute(attr_node.name) if attr_name == 'src' && attr_node.value !~ /[^[:space:]]/
-
-        Loofah::HTML5::Scrub.force_correct_attribute_escaping! node
-      end
     end
 
     # === Rails::Html::TargetScrubber

--- a/rails-html-sanitizer.gemspec
+++ b/rails-html-sanitizer.gemspec
@@ -1,21 +1,23 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'rails/html/sanitizer/version'
+require "rails/html/sanitizer/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "rails-html-sanitizer"
   spec.version       = Rails::Html::Sanitizer::VERSION
   spec.authors       = ["Rafael Mendonça França", "Kasper Timm Hansen"]
   spec.email         = ["rafaelmfranca@gmail.com", "kaspth@gmail.com"]
-  spec.description   = %q{HTML sanitization for Rails applications}
-  spec.summary       = %q{This gem is responsible to sanitize HTML fragments in Rails applications.}
+  spec.description   = "HTML sanitization for Rails applications"
+  spec.summary       = "This gem is responsible to sanitize HTML fragments in Rails applications."
   spec.homepage      = "https://github.com/rails/rails-html-sanitizer"
   spec.license       = "MIT"
 
   spec.required_ruby_version = ">= 2.5.0"
 
-  spec.metadata      = {
+  spec.metadata = {
     "bug_tracker_uri"   => "https://github.com/rails/rails-html-sanitizer/issues",
     "changelog_uri"     => "https://github.com/rails/rails-html-sanitizer/blob/v#{spec.version}/CHANGELOG.md",
     "documentation_uri" => "https://www.rubydoc.info/gems/rails-html-sanitizer/#{spec.version}",

--- a/rails-html-sanitizer.gemspec
+++ b/rails-html-sanitizer.gemspec
@@ -13,6 +13,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/rails/rails-html-sanitizer"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = ">= 2.5.0"
+
   spec.metadata      = {
     "bug_tracker_uri"   => "https://github.com/rails/rails-html-sanitizer/issues",
     "changelog_uri"     => "https://github.com/rails/rails-html-sanitizer/blob/v#{spec.version}/CHANGELOG.md",

--- a/rails-html-sanitizer.gemspec
+++ b/rails-html-sanitizer.gemspec
@@ -29,9 +29,4 @@ Gem::Specification.new do |spec|
   # NOTE: There's no need to update this dependency for Loofah CVEs
   # in minor releases when users can simply run `bundle update loofah`.
   spec.add_dependency "loofah", "~> 2.19", ">= 2.19.1"
-
-  spec.add_development_dependency "bundler", ">= 1.3"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "minitest"
-  spec.add_development_dependency "rails-dom-testing"
 end

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "minitest/autorun"
 require "rails-html-sanitizer"
 require "rails/dom/testing/assertions/dom_assertions"
@@ -9,7 +11,7 @@ class SanitizersTest < Minitest::Test
 
   def test_sanitizer_sanitize_raises_not_implemented_error
     assert_raises NotImplementedError do
-      Rails::Html::Sanitizer.new.sanitize('')
+      Rails::Html::Sanitizer.new.sanitize("")
     end
   end
 
@@ -40,16 +42,16 @@ class SanitizersTest < Minitest::Test
 
   def test_remove_xpaths_called_with_faulty_xpath
     assert_raises Nokogiri::XML::XPath::SyntaxError do
-      xpath_sanitize('<h1>hello<h1>', xpaths: %w(..faulty_xpath))
+      xpath_sanitize("<h1>hello<h1>", xpaths: %w(..faulty_xpath))
     end
   end
 
   def test_remove_xpaths_called_with_xpath_string
-    assert_equal '', xpath_sanitize('<a></a>', xpaths: './/a')
+    assert_equal "", xpath_sanitize("<a></a>", xpaths: ".//a")
   end
 
   def test_remove_xpaths_called_with_enumerable_xpaths
-    assert_equal '', xpath_sanitize('<a><span></span></a>', xpaths: %w(.//a .//span))
+    assert_equal "", xpath_sanitize("<a><span></span></a>", xpaths: %w(.//a .//span))
   end
 
   def test_strip_tags_with_quote
@@ -120,15 +122,15 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_strip_tags_with_frozen_string
-    assert_equal "Frozen string with no tags", full_sanitize("Frozen string with no tags".freeze)
+    assert_equal "Frozen string with no tags", full_sanitize("Frozen string with no tags")
   end
 
   def test_full_sanitize_respect_html_escaping_of_the_given_string
     assert_equal 'test\r\nstring', full_sanitize('test\r\nstring')
-    assert_equal '&amp;', full_sanitize('&')
-    assert_equal '&amp;', full_sanitize('&amp;')
-    assert_equal '&amp;amp;', full_sanitize('&amp;amp;')
-    assert_equal 'omg &lt;script&gt;BOM&lt;/script&gt;', full_sanitize('omg &lt;script&gt;BOM&lt;/script&gt;')
+    assert_equal "&amp;", full_sanitize("&")
+    assert_equal "&amp;", full_sanitize("&amp;")
+    assert_equal "&amp;amp;", full_sanitize("&amp;amp;")
+    assert_equal "omg &lt;script&gt;BOM&lt;/script&gt;", full_sanitize("omg &lt;script&gt;BOM&lt;/script&gt;")
   end
 
   def test_strip_links_with_tags_in_tags
@@ -162,7 +164,7 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_sanitize_form
-    assert_sanitized "<form action=\"/foo/bar\" method=\"post\"><input></form>", ''
+    assert_sanitized "<form action=\"/foo/bar\" method=\"post\"><input></form>", ""
   end
 
   def test_sanitize_plaintext
@@ -222,16 +224,16 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_should_handle_non_html
-    assert_sanitized 'abc'
+    assert_sanitized "abc"
   end
 
   def test_should_handle_blank_text
-    [nil, '', '   '].each { |blank| assert_sanitized blank }
+    [nil, "", "   "].each { |blank| assert_sanitized blank }
   end
 
   def test_setting_allowed_tags_affects_sanitization
     scope_allowed_tags %w(u) do |sanitizer|
-      assert_equal '<u></u>', sanitizer.sanitize('<a><u></u></a>')
+      assert_equal "<u></u>", sanitizer.sanitize("<a><u></u></a>")
     end
   end
 
@@ -244,8 +246,8 @@ class SanitizersTest < Minitest::Test
 
   def test_custom_tags_overrides_allowed_tags
     scope_allowed_tags %(u) do |sanitizer|
-      input = '<a><u></u></a>'
-      assert_equal '<a></a>', sanitizer.sanitize(input, tags: %w(a))
+      input = "<a><u></u></a>"
+      assert_equal "<a></a>", sanitizer.sanitize(input, tags: %w(a))
     end
   end
 
@@ -258,7 +260,7 @@ class SanitizersTest < Minitest::Test
 
   def test_should_allow_prune
     sanitizer = Rails::Html::SafeListSanitizer.new(prune: true)
-    text = '<u>leave me <b>now</b></u>'
+    text = "<u>leave me <b>now</b></u>"
     assert_equal "<u>leave me </u>", sanitizer.sanitize(text, tags: %w(u))
   end
 
@@ -279,7 +281,7 @@ class SanitizersTest < Minitest::Test
 
   def test_should_allow_custom_tags_with_custom_attributes
     text = %(<blockquote foo="bar">Lorem ipsum</blockquote>)
-    assert_equal text, safe_list_sanitize(text, attributes: ['foo'])
+    assert_equal text, safe_list_sanitize(text, attributes: ["foo"])
   end
 
   def test_scrub_style_if_style_attribute_option_is_passed
@@ -290,43 +292,43 @@ class SanitizersTest < Minitest::Test
 
   def test_should_raise_argument_error_if_tags_is_not_enumerable
     assert_raises ArgumentError do
-      safe_list_sanitize('<a>some html</a>', tags: 'foo')
+      safe_list_sanitize("<a>some html</a>", tags: "foo")
     end
   end
 
   def test_should_raise_argument_error_if_attributes_is_not_enumerable
     assert_raises ArgumentError do
-      safe_list_sanitize('<a>some html</a>', attributes: 'foo')
+      safe_list_sanitize("<a>some html</a>", attributes: "foo")
     end
   end
 
   def test_should_not_accept_non_loofah_inheriting_scrubber
     scrubber = Object.new
-    def scrubber.scrub(node); node.name = 'h1'; end
+    def scrubber.scrub(node); node.name = "h1"; end
 
     assert_raises Loofah::ScrubberNotFound do
-      safe_list_sanitize('<a>some html</a>', scrubber: scrubber)
+      safe_list_sanitize("<a>some html</a>", scrubber: scrubber)
     end
   end
 
   def test_should_accept_loofah_inheriting_scrubber
     scrubber = Loofah::Scrubber.new
-    def scrubber.scrub(node); node.name = 'h1'; end
+    def scrubber.scrub(node); node.name = "h1"; end
 
     html = "<script>hello!</script>"
     assert_equal "<h1>hello!</h1>", safe_list_sanitize(html, scrubber: scrubber)
   end
 
   def test_should_accept_loofah_scrubber_that_wraps_a_block
-    scrubber = Loofah::Scrubber.new { |node| node.name = 'h1' }
+    scrubber = Loofah::Scrubber.new { |node| node.name = "h1" }
     html = "<script>hello!</script>"
     assert_equal "<h1>hello!</h1>", safe_list_sanitize(html, scrubber: scrubber)
   end
 
   def test_custom_scrubber_takes_precedence_over_other_options
-    scrubber = Loofah::Scrubber.new { |node| node.name = 'h1' }
+    scrubber = Loofah::Scrubber.new { |node| node.name = "h1" }
     html = "<script>hello!</script>"
-    assert_equal "<h1>hello!</h1>", safe_list_sanitize(html, scrubber: scrubber, tags: ['foo'])
+    assert_equal "<h1>hello!</h1>", safe_list_sanitize(html, scrubber: scrubber, tags: ["foo"])
   end
 
   [%w(img src), %w(a href)].each do |(tag, attr)|
@@ -407,7 +409,7 @@ class SanitizersTest < Minitest::Test
 
   def test_should_sanitize_xul_style_attributes
     raw = %(-moz-binding:url('http://ha.ckers.org/xssmoz.xml#xss'))
-    assert_equal '', sanitize_css(raw)
+    assert_equal "", sanitize_css(raw)
   end
 
   def test_should_sanitize_invalid_tag_names
@@ -450,16 +452,16 @@ class SanitizersTest < Minitest::Test
 
   def test_should_sanitize_div_style_expression
     raw = %(width: expression(alert('XSS'));)
-    assert_equal '', sanitize_css(raw)
+    assert_equal "", sanitize_css(raw)
   end
 
   def test_should_sanitize_across_newlines
     raw = %(\nwidth:\nexpression(alert('XSS'));\n)
-    assert_equal '', sanitize_css(raw)
+    assert_equal "", sanitize_css(raw)
   end
 
   def test_should_sanitize_img_vbscript
-    assert_sanitized %(<img src='vbscript:msgbox("XSS")' />), '<img />'
+    assert_sanitized %(<img src='vbscript:msgbox("XSS")' />), "<img />"
   end
 
   def test_should_sanitize_cdata_section
@@ -475,7 +477,7 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_should_not_mangle_urls_with_ampersand
-     assert_sanitized %{<a href=\"http://www.domain.com?var1=1&amp;var2=2\">my link</a>}
+    assert_sanitized %{<a href=\"http://www.domain.com?var1=1&amp;var2=2\">my link</a>}
   end
 
   def test_should_sanitize_neverending_attribute
@@ -488,7 +490,7 @@ class SanitizersTest < Minitest::Test
     %(<a href="javascript&#x3A;alert('XSS');">),
     %(<a href="javascript&#x003A;alert('XSS');">)
   ].each_with_index do |enc_hack, i|
-    define_method "test_x03a_handling_#{i+1}" do
+    define_method "test_x03a_handling_#{i + 1}" do
       assert_sanitized enc_hack, "<a>"
     end
   end
@@ -499,8 +501,8 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_sanitize_ascii_8bit_string
-    safe_list_sanitize('<a>hello</a>'.encode('ASCII-8BIT')).tap do |sanitized|
-      assert_equal '<a>hello</a>', sanitized
+    safe_list_sanitize("<a>hello</a>".encode("ASCII-8BIT")).tap do |sanitized|
+      assert_equal "<a>hello</a>", sanitized
       assert_equal Encoding::UTF_8, sanitized.encoding
     end
   end
@@ -512,7 +514,7 @@ class SanitizersTest < Minitest::Test
 
   def test_allow_data_attribute_if_requested
     text = %(<a data-foo="foo">foo</a>)
-    assert_equal %(<a data-foo="foo">foo</a>), safe_list_sanitize(text, attributes: ['data-foo'])
+    assert_equal %(<a data-foo="foo">foo</a>), safe_list_sanitize(text, attributes: ["data-foo"])
   end
 
   def test_uri_escaping_of_href_attr_in_a_tag_in_safe_list_sanitizer
@@ -568,7 +570,7 @@ class SanitizersTest < Minitest::Test
 
     html = %{<a action='examp<!--" unsafeattr=foo()>-->le.com'>test</a>}
 
-    text = safe_list_sanitize(html, attributes: ['action'])
+    text = safe_list_sanitize(html, attributes: ["action"])
 
     acceptable_results = [
       # nokogiri w/vendored+patched libxml2
@@ -602,44 +604,44 @@ class SanitizersTest < Minitest::Test
   end
 
   def test_mediatype_text_html_disallowed
-    input = %q(<img src="data:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">)
-    expected = %q(<img>)
+    input = '<img src="data:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">'
+    expected = "<img>"
     actual = safe_list_sanitize(input)
     assert_equal(expected, actual)
 
-    input = %q(<img src="DATA:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">)
-    expected = %q(<img>)
+    input = '<img src="DATA:text/html;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">'
+    expected = "<img>"
     actual = safe_list_sanitize(input)
     assert_equal(expected, actual)
   end
 
   def test_mediatype_image_svg_xml_disallowed
-    input = %q(<img src="data:image/svg+xml;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">)
-    expected = %q(<img>)
+    input = '<img src="data:image/svg+xml;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">'
+    expected = "<img>"
     actual = safe_list_sanitize(input)
     assert_equal(expected, actual)
 
-    input = %q(<img src="DATA:image/svg+xml;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">)
-    expected = %q(<img>)
+    input = '<img src="DATA:image/svg+xml;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">'
+    expected = "<img>"
     actual = safe_list_sanitize(input)
     assert_equal(expected, actual)
   end
 
   def test_mediatype_other_disallowed
-    input = %q(<a href="data:foo;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">foo</a>)
-    expected = %q(<a>foo</a>)
+    input = '<a href="data:foo;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">foo</a>'
+    expected = "<a>foo</a>"
     actual = safe_list_sanitize(input)
     assert_equal(expected, actual)
 
-    input = %q(<a href="DATA:foo;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">foo</a>)
-    expected = %q(<a>foo</a>)
+    input = '<a href="DATA:foo;base64,PHNjcmlwdD5hbGVydCgnWFNTJyk8L3NjcmlwdD4=">foo</a>'
+    expected = "<a>foo</a>"
     actual = safe_list_sanitize(input)
     assert_equal(expected, actual)
   end
 
   def test_scrubbing_svg_attr_values_that_allow_ref
-    input = %Q(<div fill="yellow url(http://bad.com/) #fff">hey</div>)
-    expected = %Q(<div fill="yellow #fff">hey</div>)
+    input = '<div fill="yellow url(http://bad.com/) #fff">hey</div>'
+    expected = '<div fill="yellow #fff">hey</div>'
     actual = scope_allowed_attributes %w(fill) do
       safe_list_sanitize(input)
     end
@@ -708,7 +710,6 @@ class SanitizersTest < Minitest::Test
   end
 
 protected
-
   def xpath_sanitize(input, options = {})
     XpathRemovalTestSanitizer.new.sanitize(input, options)
   end
@@ -754,7 +755,7 @@ protected
   end
 
   # note that this is used for testing CSS hex encoding: \\[0-9a-f]{1,6}
-  def convert_to_css_hex(string, escape_parens=false)
+  def convert_to_css_hex(string, escape_parens = false)
     string.chars.map do |c|
       if !escape_parens && (c == "(" || c == ")")
         c

--- a/test/scrubbers_test.rb
+++ b/test/scrubbers_test.rb
@@ -1,9 +1,10 @@
+# frozen_string_literal: true
+
 require "minitest/autorun"
 require "rails-html-sanitizer"
 
 class ScrubberTest < Minitest::Test
   protected
-
     def assert_scrubbed(html, expected = html)
       output = Loofah.scrub_fragment(html, @scrubber).to_s
       assert_equal expected, output
@@ -28,7 +29,6 @@ class ScrubberTest < Minitest::Test
 end
 
 class PermitScrubberTest < ScrubberTest
-
   def setup
     @scrubber = Rails::Html::PermitScrubber.new
   end
@@ -38,51 +38,51 @@ class PermitScrubberTest < ScrubberTest
   end
 
   def test_default_scrub_behavior
-    assert_scrubbed '<tag>hello</tag>', 'hello'
+    assert_scrubbed "<tag>hello</tag>", "hello"
   end
 
   def test_default_scrub_removes_comments
-    assert_scrubbed('<div>one</div><!-- two --><span>three</span>',
-                    '<div>one</div><span>three</span>')
+    assert_scrubbed("<div>one</div><!-- two --><span>three</span>",
+                    "<div>one</div><span>three</span>")
   end
 
   def test_default_scrub_removes_processing_instructions
-    assert_scrubbed('<div>one</div><?div two><span>three</span>',
-                    '<div>one</div><span>three</span>')
+    assert_scrubbed("<div>one</div><?div two><span>three</span>",
+                    "<div>one</div><span>three</span>")
   end
 
   def test_default_attributes_removal_behavior
-    assert_scrubbed '<p cooler="hello">hello</p>', '<p>hello</p>'
+    assert_scrubbed '<p cooler="hello">hello</p>', "<p>hello</p>"
   end
 
   def test_leaves_supplied_tags
     @scrubber.tags = %w(a)
-    assert_scrubbed '<a>hello</a>'
+    assert_scrubbed "<a>hello</a>"
   end
 
   def test_leaves_only_supplied_tags
-    html = '<tag>leave me <span>now</span></tag>'
+    html = "<tag>leave me <span>now</span></tag>"
     @scrubber.tags = %w(tag)
-    assert_scrubbed html, '<tag>leave me now</tag>'
+    assert_scrubbed html, "<tag>leave me now</tag>"
   end
 
   def test_prunes_tags
     @scrubber = Rails::Html::PermitScrubber.new(prune: true)
     @scrubber.tags = %w(tag)
-    html = '<tag>leave me <span>now</span></tag>'
-    assert_scrubbed html, '<tag>leave me </tag>'
+    html = "<tag>leave me <span>now</span></tag>"
+    assert_scrubbed html, "<tag>leave me </tag>"
   end
 
   def test_leaves_comments_when_supplied_as_tag
     @scrubber.tags = %w(div comment)
-    assert_scrubbed('<div>one</div><!-- two --><span>three</span>',
-                    '<div>one</div><!-- two -->three')
+    assert_scrubbed("<div>one</div><!-- two --><span>three</span>",
+                    "<div>one</div><!-- two -->three")
   end
 
   def test_leaves_only_supplied_tags_nested
-    html = '<tag>leave <em>me <span>now</span></em></tag>'
+    html = "<tag>leave <em>me <span>now</span></em></tag>"
     @scrubber.tags = %w(tag)
-    assert_scrubbed html, '<tag>leave me now</tag>'
+    assert_scrubbed html, "<tag>leave me now</tag>"
   end
 
   def test_leaves_supplied_attributes
@@ -109,16 +109,16 @@ class PermitScrubberTest < ScrubberTest
   end
 
   def test_leaves_text
-    assert_scrubbed('some text')
+    assert_scrubbed("some text")
   end
 
   def test_skips_text_nodes
-    assert_node_skipped('some text')
+    assert_node_skipped("some text")
   end
 
   def test_tags_accessor_validation
     e = assert_raises(ArgumentError) do
-      @scrubber.tags = 'tag'
+      @scrubber.tags = "tag"
     end
 
     assert_equal "You should pass :tags as an Enumerable", e.message
@@ -127,7 +127,7 @@ class PermitScrubberTest < ScrubberTest
 
   def test_attributes_accessor_validation
     e = assert_raises(ArgumentError) do
-      @scrubber.attributes = 'cooler'
+      @scrubber.attributes = "cooler"
     end
 
     assert_equal "You should pass :attributes as an Enumerable", e.message
@@ -142,14 +142,14 @@ class TargetScrubberTest < ScrubberTest
 
   def test_targeting_tags_removes_only_them
     @scrubber.tags = %w(a h1)
-    html = '<script></script><a></a><h1></h1>'
-    assert_scrubbed html, '<script></script>'
+    html = "<script></script><a></a><h1></h1>"
+    assert_scrubbed html, "<script></script>"
   end
 
   def test_targeting_tags_removes_only_them_nested
     @scrubber.tags = %w(a)
-    html = '<tag><a><tag><a></a></tag></a></tag>'
-    assert_scrubbed html, '<tag><tag></tag></tag>'
+    html = "<tag><a><tag><a></a></tag></a></tag>"
+    assert_scrubbed html, "<tag><tag></tag></tag>"
   end
 
   def test_targeting_attributes_removes_only_them
@@ -168,8 +168,8 @@ class TargetScrubberTest < ScrubberTest
   def test_prunes_tags
     @scrubber = Rails::Html::TargetScrubber.new(prune: true)
     @scrubber.tags = %w(span)
-    html = '<tag>leave me <span>now</span></tag>'
-    assert_scrubbed html, '<tag>leave me </tag>'
+    html = "<tag>leave me <span>now</span></tag>"
+    assert_scrubbed html, "<tag>leave me </tag>"
   end
 end
 
@@ -179,11 +179,11 @@ class TextOnlyScrubberTest < ScrubberTest
   end
 
   def test_removes_all_tags_and_keep_the_content
-    assert_scrubbed '<tag>hello</tag>', 'hello'
+    assert_scrubbed "<tag>hello</tag>", "hello"
   end
 
   def test_skips_text_nodes
-    assert_node_skipped('some text')
+    assert_node_skipped("some text")
   end
 end
 
@@ -199,6 +199,6 @@ class ReturningStopFromScrubNodeTest < ScrubberTest
   end
 
   def test_returns_stop_from_scrub_if_scrub_node_does
-    assert_scrub_stopped '<script>remove me</script>'
+    assert_scrub_stopped "<script>remove me</script>"
   end
 end


### PR DESCRIPTION
In this PR:

- import `.rubocop.yml` from rails/rails
- move development dependencies from gemspec to `Gemfile`
- set required_ruby_version to ">= 2.5.0"
- correct all rubocop warnings

Note that Ruby 2.5 matches the oldest supported version of Rails (6.0/6.1).