### PR TITLE
dep: support older versions of Nokogiri and Loofah

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,18 @@ jobs:
           bundler-cache: true
       - run: bundle exec rake
 
+  cruby-old-dependencies:
+    runs-on: ubuntu-latest
+    env:
+      TEST_WITH_OLD_DEPENDENCIES: t
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "2.5"
+          bundler-cache: true
+      - run: bundle exec rake
+
   cruby-nokogiri-system-libraries:
     runs-on: ubuntu-20.04
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :rubocop do
   gem "rubocop-rails", require: false
 end
 
-# specify gem versions for old rubies
-gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-gem "activesupport", RUBY_VERSION < "2.2.2" ? "~> 4.2.0" : ">= 5"
+if ENV["TEST_WITH_OLD_DEPENDENCIES"]
+  gem "nokogiri", "< 1.12.0"
+  gem "loofah", "< 2.21.0"
+end

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ The following aliases are maintained for backwards compatibility:
 
 All sanitizers respond to `sanitize`, and are available in variants that use either HTML4 or HTML5 parsing, under the `Rails::HTML4` and `Rails::HTML5` namespaces, respectively.
 
+NOTE: The HTML5 sanitizers require Nokogiri >= 1.14 and Loofah >= 2.21, and are not supported on JRuby. Users may programmatically check for support by calling `Rails::HTML::Sanitizer.html5_support?` or `defined?(Rails::HTML5::Sanitizer)`.
+
+
 #### FullSanitizer
 
 ```ruby

--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -39,7 +39,7 @@ module Rails
       module Parser
         module HTML4
           def parse_fragment(html)
-            Loofah.html4_fragment(html)
+            Loofah.fragment(html) # TODO: update to html4_fragment when we require Loofah >= 2.21
           end
         end
 

--- a/test/rails_api_test.rb
+++ b/test/rails_api_test.rb
@@ -71,4 +71,9 @@ class RailsApiTest < Minitest::Test
     skip("no HTML5 support on this platform") unless Rails::HTML::Sanitizer.html5_support?
     assert_equal(Rails::HTML5::SafeListSanitizer, Rails::HTML5::Sanitizer.white_list_sanitizer)
   end
+
+  def test_html5_sanitizer_not_defined_if_not_supported
+    skip("HTML5 is supported on this platform") if Rails::HTML::Sanitizer.html5_support?
+    assert_nil(defined?(Rails::HTML5::Sanitizer))
+  end
 end


### PR DESCRIPTION
THIS IS VARIATION 1 - see variation 2 at #166 

If we want to support Rails 6.1+ (and Ruby 2.5) we need to do this. The alternative (#166) is to pin to newer versions and only support Rails 7.0+ (Ruby 2.7).

Update CI to run with pre-HTML5 versions of Nokogiri and Loofah on Ruby 2.5.
