### PR TITLE
dep: update loofah and nokogiri to versions fully supporting HTML5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2", "ruby-head", "truffleruby-head"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "ruby-head", "truffleruby-head", "jruby-9.4", "jruby-head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.1"
+          ruby-version: "3.2"
       - name: Install nokogiri with system libraries
         run: |
           sudo apt install pkg-config libxml2-dev libxslt-dev
@@ -54,18 +54,4 @@ jobs:
           bundle config build.nokogiri --enable-system-libraries
           bundle install
           bundle exec nokogiri -v
-      - run: bundle exec rake
-
-  jruby:
-    strategy:
-      fail-fast: false
-      matrix:
-        ruby: ["jruby-9.3", "jruby-9.4", "jruby-head"]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{matrix.ruby}}
-          bundler-cache: true
       - run: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ The following aliases are maintained for backwards compatibility:
 
 All sanitizers respond to `sanitize`, and are available in variants that use either HTML4 or HTML5 parsing, under the `Rails::HTML4` and `Rails::HTML5` namespaces, respectively.
 
+NOTE: The HTML5 sanitizers are not supported on JRuby. Users may programmatically check for support by calling `Rails::HTML::Sanitizer.html5_support?`.
+
+
 #### FullSanitizer
 
 ```ruby

--- a/rails-html-sanitizer.gemspec
+++ b/rails-html-sanitizer.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/rails/rails-html-sanitizer"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata = {
     "bug_tracker_uri"   => "https://github.com/rails/rails-html-sanitizer/issues",
@@ -26,7 +26,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
-  # NOTE: There's no need to update this dependency for Loofah CVEs
-  # in minor releases when users can simply run `bundle update loofah`.
-  spec.add_dependency "loofah", "~> 2.19", ">= 2.19.1"
+  # NOTE: There's no need to update dependencies for CVEs in minor releases
+  # when users can simply run `bundle update loofah`.
+  spec.add_dependency "loofah", "~> 2.21"
+  spec.add_dependency "nokogiri", "~> 1.14"
 end


### PR DESCRIPTION
THIS IS VARIATION 2 - see variation 1 at #164 

Require versions of Nokogiri and Loofah that support HTML5:

- loofah v2.21.x introduced Rails::HTML5::Sanitizer
- nokogiri v1.14.x is needed for loofah to subclass Nokogiri::HTML5::{Document,DocumentFragment}

Update required_ruby_version to ">= 2.7.0" to match Nokogiri's constraint for v1.14.x.

Update CI to only test supported Ruby versions.

The alternative (#164) is to continue to support older versions of Nokogiri (for Ruby 2.5) and Loofah.