### PR TITLE
feat: introduce Rails::HTML::Sanitizer.best_supported_vendor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.6.0.rc1 / 2023-05-24
 
-* Sanitizers that use an HTML5 parser are now available on platforms supported by
+* HTML5 standards-compliant sanitizers are now available on platforms supported by
   Nokogiri::HTML5. These are available as:
 
   - `Rails::HTML5::FullSanitizer`
@@ -12,6 +12,9 @@
 
   Note that for symmetry `Rails::HTML4::Sanitizer` is also added, though its behavior is identical
   to the vendor class methods on `Rails::HTML::Sanitizer`.
+
+  Users may call `Rails::HTML::Sanitizer.best_supported_vendor` to get back the HTML5 vendor if it's
+  supported, else the legacy HTML4 vendor.
 
   *Mike Dalessio*
 

--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -9,6 +9,10 @@ module Rails
 
           @html5_support = Loofah.respond_to?(:html5_support?) && Loofah.html5_support?
         end
+
+        def best_supported_vendor
+          html5_support? ? Rails::HTML5::Sanitizer : Rails::HTML4::Sanitizer
+        end
       end
 
       def sanitize(html, options = {})

--- a/test/rails_api_test.rb
+++ b/test/rails_api_test.rb
@@ -17,6 +17,20 @@ class RailsApiTest < Minitest::Test
     assert(Rails::Html::Sanitizer)
   end
 
+  def test_best_supported_vendor_when_html5_is_not_supported_returns_html4
+    Rails::HTML::Sanitizer.stub(:html5_support?, false) do
+      assert_equal(Rails::HTML4::Sanitizer, Rails::HTML::Sanitizer.best_supported_vendor)
+    end
+  end
+
+  def test_best_supported_vendor_when_html5_is_supported_returns_html5
+    skip("no HTML5 support on this platform") unless Rails::HTML::Sanitizer.html5_support?
+
+    Rails::HTML::Sanitizer.stub(:html5_support?, true) do
+      assert_equal(Rails::HTML5::Sanitizer, Rails::HTML::Sanitizer.best_supported_vendor)
+    end
+  end
+
   def test_html4_sanitizer_alias_full
     assert_equal(Rails::HTML4::FullSanitizer, Rails::HTML::FullSanitizer)
     assert_equal("Rails::HTML4::FullSanitizer", Rails::HTML::FullSanitizer.name)


### PR DESCRIPTION
so that callers don't need to check `html5_support?` to choose the best parser available.

The conditionals are making Rails integration harder than it needs to be, see https://github.com/rails/rails/pull/48293