### PR TITLE
use railtie to set default sanitizer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,7 @@ end
 # specify gem versions for old rubies
 gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
 gem "activesupport", RUBY_VERSION < "2.2.2" ? "~> 4.2.0" : ">= 5"
+
+group :test do
+  gem "rails", "~> 7.1.1"
+end

--- a/lib/rails-html-sanitizer.rb
+++ b/lib/rails-html-sanitizer.rb
@@ -59,3 +59,5 @@ module ActionView
     end
   end
 end
+
+require_relative "railtie"

--- a/lib/railtie.rb
+++ b/lib/railtie.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails"
+require "rails/html/sanitizer"
+
+module Rails
+  module HTML
+    class Sanitizer
+      class Railtie < Rails::Railtie # :nodoc:
+        initializer "rails_html_sanitizer.sanitizer_vendor" do |app|
+          ActiveSupport.on_load(:action_view) do
+            ActionView::Helpers::SanitizeHelper.sanitizer_vendor = Rails::HTML4::Sanitizer
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

This PR sets the default sanitizer in a railtie.

## Why

This requires a bit of explanation. Setting the default sanitizer in a railtie allows actionview to be used with frameworks other than Rails. In this case, I'm using actionview with [Jets](https://rubyonjets.com/). 

I've found that the only spot in actionview that refers to `Rails` is the use of rails-html-sanitizer in helpers/santize_helper.rb

* https://github.com/rails/rails/blob/53438e9216243fb75400c8800ddf549daa52eab3/actionview/lib/action_view/helpers/sanitize_helper.rb#L3
* https://github.com/rails/rails/blob/53438e9216243fb75400c8800ddf549daa52eab3/actionview/lib/action_view/helpers/sanitize_helper.rb#L12

This couples Rails to ActionView, and it makes ActionView challenging to use with other frameworks. I'm using some hacky workarounds with Kernel require for Jets.

Related PR on the actionview side https://github.com/rails/rails/pull/49643 Thanks for considering the PR.
