### PR TITLE
Remove checks for Ruby versions no longer supported

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,5 +16,5 @@ group :rubocop do
 end
 
 # specify gem versions for old rubies
-gem "nokogiri", RUBY_VERSION < "2.1" ? "~> 1.6.0" : ">= 1.7"
-gem "activesupport", RUBY_VERSION < "2.2.2" ? "~> 4.2.0" : ">= 5"
+gem "nokogiri", ">= 1.7"
+gem "activesupport", ">= 5"

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -728,8 +728,6 @@ module SanitizerTests
     end
 
     def test_uri_escaping_of_href_attr_in_a_tag_in_safe_list_sanitizer
-      skip if RUBY_VERSION < "2.3"
-
       html = %{<a href='examp<!--" unsafeattr=foo()>-->le.com'>test</a>}
 
       text = safe_list_sanitize(html)
@@ -747,8 +745,6 @@ module SanitizerTests
     end
 
     def test_uri_escaping_of_src_attr_in_a_tag_in_safe_list_sanitizer
-      skip if RUBY_VERSION < "2.3"
-
       html = %{<a src='examp<!--" unsafeattr=foo()>-->le.com'>test</a>}
 
       text = safe_list_sanitize(html)
@@ -766,8 +762,6 @@ module SanitizerTests
     end
 
     def test_uri_escaping_of_name_attr_in_a_tag_in_safe_list_sanitizer
-      skip if RUBY_VERSION < "2.3"
-
       html = %{<a name='examp<!--" unsafeattr=foo()>-->le.com'>test</a>}
 
       text = safe_list_sanitize(html)
@@ -785,8 +779,6 @@ module SanitizerTests
     end
 
     def test_uri_escaping_of_name_action_in_a_tag_in_safe_list_sanitizer
-      skip if RUBY_VERSION < "2.3"
-
       html = %{<a action='examp<!--" unsafeattr=foo()>-->le.com'>test</a>}
 
       text = safe_list_sanitize(html, attributes: ["action"])


### PR DESCRIPTION
The Gem specifies a version of Ruby greater than or equal to 2.7.0