### PR TITLE
Add <mark> to DEFAULT_ALLOWED_TAGS

### DIFF
--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -106,6 +106,7 @@ module Rails
                                            "ins",
                                            "kbd",
                                            "li",
+                                           "mark",
                                            "ol",
                                            "p",
                                            "pre",


### PR DESCRIPTION
This is a safe tag and a common use case for `sanitize` in Rails: It's a semantic tag that's useful when showing search results. Search results can contain user input. Hence, best practice is to run them through `sanitize`.

E.g., in my code:

```ruby
sanitize(search_hit_html, tags: %w[mark])
```

* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark
