### PR TITLE
Fix ReDoS Vulnerability in PermitScrubber and Add Performance Test

### DIFF
--- a/lib/rails/html/scrubbers.rb
+++ b/lib/rails/html/scrubbers.rb
@@ -150,7 +150,7 @@ module Rails
             Loofah::HTML5::Scrub.scrub_attribute_that_allows_local_ref(attr_node)
           end
 
-          if Loofah::HTML5::SafeList::SVG_ALLOW_LOCAL_HREF.include?(node.name) && attr_name == "xlink:href" && attr_node.value =~ /^\s*[^#\s].*/m
+          if Loofah::HTML5::SafeList::SVG_ALLOW_LOCAL_HREF.include?(node.name) && attr_name == "xlink:href" && attr_node.value =~ /^\s*[^#].*/m
             attr_node.remove
           end
 

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -1026,26 +1026,6 @@ module SanitizerTests
       assert_equal "", sanitize_css(raw)
     end
 
-
-    def test_linear_perfomance_svg
-      seq = [5000, 10000, 20000, 40000]
-      times = []
-
-      seq.each do |n|
-        payload = "<svg><set xlink:href='#{"\n" * n}'/></svg>"
-        elapsed_time = Benchmark.realtime {
-          safe_list_sanitize(payload)
-        }
-        times << elapsed_time
-      end
-
-      # Manually check for linear performance growth
-      times.each_cons(2) do |prev_time, next_time|
-        assert_operator next_time, :<, prev_time * 4, "ReDoS vulnerability detected! Execution time increased too rapidly."
-      end
-    end
-
-
     protected
       def safe_list_sanitize(input, options = {})
         module_under_test::SafeListSanitizer.new.sanitize(input, options)

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -1026,6 +1026,26 @@ module SanitizerTests
       assert_equal "", sanitize_css(raw)
     end
 
+
+    def test_linear_perfomance_svg
+      seq = [5000, 10000, 20000, 40000]
+      times = []
+
+      seq.each do |n|
+        payload = "<svg><set xlink:href='#{"\n" * n}'/></svg>"
+        elapsed_time = Benchmark.realtime {
+          safe_list_sanitize(payload)
+        }
+        times << elapsed_time
+      end
+
+      # Manually check for linear performance growth
+      times.each_cons(2) do |prev_time, next_time|
+        assert_operator next_time, :<, prev_time * 4, "ReDoS vulnerability detected! Execution time increased too rapidly."
+      end
+    end
+
+
     protected
       def safe_list_sanitize(input, options = {})
         module_under_test::SafeListSanitizer.new.sanitize(input, options)

--- a/test/scrubbers_test.rb
+++ b/test/scrubbers_test.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "benchmark"
 require "minitest/autorun"
 require "rails-html-sanitizer"
 


### PR DESCRIPTION
This pull request addresses a Regular Expression Denial of Service (ReDoS) vulnerability in the `PermitScrubber` class of the `rails-html-sanitizer` library. The vulnerability, caused by a regex pattern with potential for excessive backtracking, has been mitigated by optimizing the regular expression used in the `scrub_attribute` method.