### PR TITLE
performance: eliminate operations on removed nodes

### DIFF
--- a/lib/rails/html/scrubbers.rb
+++ b/lib/rails/html/scrubbers.rb
@@ -108,8 +108,11 @@ module Rails
         def scrub_attributes(node)
           if @attributes
             node.attribute_nodes.each do |attr|
-              attr.remove if scrub_attribute?(attr.name)
-              scrub_attribute(node, attr)
+              if scrub_attribute?(attr.name)
+                attr.remove
+              else
+                scrub_attribute(node, attr)
+              end
             end
 
             scrub_css_attribute(node)

--- a/lib/rails/html/scrubbers.rb
+++ b/lib/rails/html/scrubbers.rb
@@ -72,10 +72,11 @@ module Rails
         return CONTINUE if skip_node?(node)
 
         unless (node.element? || node.comment?) && keep_node?(node)
-          return STOP if scrub_node(node) == STOP
+          return STOP unless scrub_node(node) == CONTINUE
         end
 
         scrub_attributes(node)
+        CONTINUE
       end
 
       protected

--- a/test/scrubbers_test.rb
+++ b/test/scrubbers_test.rb
@@ -249,6 +249,16 @@ class PermitScrubberMinimalOperationsTest < ScrubberTest
     end
   end
 
+  def test_does_not_scrub_removed_attributes
+    @scrubber = TestPermitScrubber.new
+
+    input = "<div class='foo' href='bar'></div>"
+    frag = scrub_fragment(input)
+    assert_equal("<div class=\"foo\"></div>", frag)
+
+    assert_equal([["div", "class"]], @scrubber.instance_variable_get(:@scrub_attribute_args))
+  end
+
   def test_does_not_scrub_attributes_of_a_removed_node
     @scrubber = TestPermitScrubber.new
 


### PR DESCRIPTION
This PR eliminates needless operations on:

- the attributes of a node that has been removed
- the contents of an attribute that has been removed
