### PR TITLE
If passed Range shorthand (duck typed), handle as text

### DIFF
--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -34,6 +34,7 @@ module Rails
       module ComposedSanitize
         def sanitize(html, options = {})
           return unless html
+          html = html.instance_of?(Range) ? html.to_s : html
           return html if html.empty?
 
           serialize(scrub(parse_fragment(html), options))

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -137,6 +137,16 @@ module SanitizerTests
       assert_includes(acceptable_results, result)
     end
 
+    def test_strip_passed_passed_duck_typed_range
+      input = 2000..2005
+      result = full_sanitize(input)
+      acceptable_results = [
+        "2000..2005",
+      ]
+
+      assert_includes(acceptable_results, result)
+    end
+
     def test_strip_blank_string
       assert_nil full_sanitize(nil)
       assert_equal "", full_sanitize("")
@@ -209,6 +219,10 @@ module SanitizerTests
 
     def test_strip_links_with_unclosed_tags
       assert_equal "", link_sanitize("<a<a")
+    end
+
+    def test_strip_links_with_passed_duck_typed_range
+      assert_equal "2001..2005", link_sanitize(2001..2005)
     end
 
     def test_strip_links_with_plaintext
@@ -295,6 +309,10 @@ module SanitizerTests
       assert_sanitized "<form action=\"/foo/bar\" method=\"post\"><input></form>", ""
     end
 
+    def test_sanitize_passed_duck_typed_range
+      assert_sanitized 2001..2005, "2001..2005"
+    end
+
     def test_sanitize_plaintext
       # note that the `plaintext` tag has been deprecated since HTML 2
       # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/plaintext
@@ -306,7 +324,19 @@ module SanitizerTests
         # xerces+nekohtml-unit
         "&lt;span&gt;foo&lt;/span&gt;&lt;/plaintext&gt;",
         # xerces+cyberneko
-        "&lt;span&gt;foo&lt;/span&gt;"
+        "&lt;span&gt;foo&lt;/span&gt;",
+      ]
+
+      assert_includes(acceptable_results, result)
+    end
+
+    def test_safe_sanitize_passed_duck_typed_range
+      # note that the `plaintext` tag has been deprecated since HTML 2
+      # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/plaintext
+      input = 2001..2005
+      result = safe_list_sanitize(input)
+      acceptable_results = [
+        "2001..2005",
       ]
 
       assert_includes(acceptable_results, result)

--- a/test/sanitizer_test.rb
+++ b/test/sanitizer_test.rb
@@ -138,10 +138,10 @@ module SanitizerTests
     end
 
     def test_strip_passed_passed_duck_typed_range
-      input = 2000..2005
+      input = 2001..2005
       result = full_sanitize(input)
       acceptable_results = [
-        "2000..2005",
+        "2001..2005",
       ]
 
       assert_includes(acceptable_results, result)
@@ -222,6 +222,7 @@ module SanitizerTests
     end
 
     def test_strip_links_with_passed_duck_typed_range
+      assert_equal "2001..2005", link_sanitize(Range.new(2001, 2005))
       assert_equal "2001..2005", link_sanitize(2001..2005)
     end
 
@@ -310,6 +311,7 @@ module SanitizerTests
     end
 
     def test_sanitize_passed_duck_typed_range
+      assert_sanitized Range.new(2001, 2005), "2001..2005"
       assert_sanitized 2001..2005, "2001..2005"
     end
 


### PR DESCRIPTION
We ran across a weird corner case when using the blacklight and blacklight_range_limit gems. Where if the text passed to sanitize gets duck typed to a range, then an error is raised. 

The range will get past the initial short circuit because it's a valid object but then will fail on the empty? call because range doesn't have the method empty? on it. 

I've added a few tests as best I could although I might have missed one or two. The modified the checks to handle a range by checking if it's an instance of Range and if so then calling to_s on it so that it can merrily pass along through the sanitization process. 

Any input is appreciated. 