### PR TITLE
ci: bump the matrices

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - run: rm Gemfile.lock
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: "3.4"
           bundler-cache: true
       - run: bundle exec rubocop
 
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "ruby-head", "truffleruby-head", "jruby-9.4", "jruby-head"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "ruby-head", "truffleruby-head", "jruby-9.4", "jruby-10.0", "jruby-head"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
       - run: bundle exec rake
 
   cruby-nokogiri-system-libraries:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: rm Gemfile.lock


### PR DESCRIPTION
specfically the ubuntu 20.04 image has been retired and that test was no longer running.