### PR TITLE
Add dependency on minitest-mock for MT6 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,12 @@ gemspec
 gem "rake"
 gem "minitest"
 
+# MT6 restricts supported versions, therefore older Rubies sticks with MT5,
+# which includes `minitest/mock`
+if RUBY_VERSION >= "3.2"
+  gem "minitest-mock"
+end
+
 group :rubocop do
   gem "rubocop", ">= 1.25.1", require: false
   gem "rubocop-minitest", require: false

--- a/test/rails_api_test.rb
+++ b/test/rails_api_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "minitest/autorun"
+require "minitest/mock"
 require "rails-html-sanitizer"
 
 class RailsApiTest < Minitest::Test


### PR DESCRIPTION
This prevents test errors with minitest 6+ such as:

~~~
  1) Error:
RailsApiTest#test_best_supported_vendor_when_html5_is_not_supported_returns_html4: NoMethodError: undefined method 'stub' for class Rails::HTML::Sanitizer
    test/rails_api_test.rb:21:in 'RailsApiTest#test_best_supported_vendor_when_html5_is_not_supported_returns_html4'

  2) Error:
RailsApiTest#test_best_supported_vendor_when_html5_is_supported_returns_html5: NoMethodError: undefined method 'stub' for class Rails::HTML::Sanitizer
    test/rails_api_test.rb:29:in 'RailsApiTest#test_best_supported_vendor_when_html5_is_supported_returns_html5'
~~~

This is due to minitest-mock being extracted from Minitest 6+:

https://github.com/minitest/minitest/commit/de9aac1d3f52224ae5d93a186d129c72d5ec979f

Please note that the condition is in this way, because MT6 restrict upport to Ruby 3.2+ [[1], [2]]

[1]: https://github.com/minitest/minitest-mock/issues/4
[2]: https://github.com/minitest/minitest/issues/1058