### PR TITLE
Reduce gem size by excluding test files

### DIFF
--- a/rails-html-sanitizer.gemspec
+++ b/rails-html-sanitizer.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   }
 
   spec.files         = Dir["lib/**/*", "README.md", "MIT-LICENSE", "CHANGELOG.md"]
-  spec.test_files    = Dir["test/**/*"]
   spec.require_paths = ["lib"]
 
   spec.add_dependency "loofah", "~> 2.25"


### PR DESCRIPTION
This pull request updates the *.gemspec file to optimize the gem package size and structure

```bash
$ gem build -o before.tar

$ git switch reduce-gem-size

$ gem build -o after.tar

$ du -sh before.tar after.tar
 28K	before.tar
 16K	after.tar
 ```
 
| Metric | Before | After | Saved                 |
|--------|--------|-------|-----------------------|
| Size   | 28K   | 16K   | −12K (⏷ −42.9%)      |


###  whitch files was deleted?

```diff
data
 ├── lib
 │   ├── rails
 │   │   └── html
 │   │       ├── sanitizer
 │   │       │   └── version.rb
 │   │       ├── sanitizer.rb
 │   │       └── scrubbers.rb
 │   └── rails-html-sanitizer.rb
-├── test
-│   ├── rails_api_test.rb
-│   ├── sanitizer_test.rb
-│   ├── scrubbers_test.rb
-│   └── test_helper.rb
 ├── CHANGELOG.md
 ├── MIT-LICENSE
 └── README.md
```

ps: you can see on [rails repo](https://github.com/rails/rails/blob/main/actioncable/actioncable.gemspec#L20)