### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
   rubocop:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - run: rm Gemfile.lock
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -32,15 +32,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Run actionlint
-        uses: rhysd/actionlint@v1.7.11
+        uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@v0.5.2
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
         with:
           advanced-security: false
 
@@ -51,9 +51,9 @@ jobs:
         ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "4.0", "ruby-head", "truffleruby-head", "jruby-9.4", "jruby-10.0", "jruby-head"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - run: rm Gemfile.lock
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true
@@ -62,9 +62,9 @@ jobs:
   cruby-nokogiri-system-libraries:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - run: rm Gemfile.lock
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:
           ruby-version: "4.0"
       - name: Install nokogiri with system libraries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - run: rm Gemfile.lock
-      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # zizmor: ignore[cache-poisoning] -- cached gems are used for testing, not release artifact generation # v1.316.0
         with:
           ruby-version: "4.0"
           bundler-cache: true
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - run: rm Gemfile.lock
-      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
+      - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # zizmor: ignore[cache-poisoning] -- cached gems are used for testing, not release artifact generation # v1.316.0
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,23 @@ jobs:
           bundler-cache: true
       - run: bundle exec rubocop
 
+  lint-actions:
+    name: GitHub Actions audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@v1.7.11
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@v0.5.2
+        with:
+          advanced-security: false
+
   cruby:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,17 @@ on:
     branches:
       - '*'
 
+permissions: {}
+
 jobs:
   rubocop:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - run: rm Gemfile.lock
       - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # zizmor: ignore[cache-poisoning] -- cached gems are used for testing, not release artifact generation # v1.316.0
         with:
@@ -30,6 +36,8 @@ jobs:
   lint-actions:
     name: GitHub Actions audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -50,8 +58,12 @@ jobs:
       matrix:
         ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4", "4.0", "ruby-head", "truffleruby-head", "jruby-9.4", "jruby-10.0", "jruby-head"]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - run: rm Gemfile.lock
       - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # zizmor: ignore[cache-poisoning] -- cached gems are used for testing, not release artifact generation # v1.316.0
         with:
@@ -61,8 +73,12 @@ jobs:
 
   cruby-nokogiri-system-libraries:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - run: rm Gemfile.lock
       - uses: ruby/setup-ruby@d45b1a4e94b71acab930e56e79c6aa188764e7f9 # v1.316.0
         with:


### PR DESCRIPTION
This hardens the CI workflow against supply chain and token exfiltration risks, and adds continuous auditing so it stays that way.

## What changed

- Added a `lint-actions` CI job that runs [actionlint](https://github.com/rhysd/actionlint) and [zizmor](https://docs.zizmor.sh) on every workflow run.
- Configured dependabot to batch github-actions updates into a weekly PR with a 7 day cooldown.
- Pinned all actions to SHA hashes using [pinact](https://github.com/suzuki-shunsuke/pinact). `ruby/setup-ruby` is pinned to v1.316.0 rather than the latest v1.317.0 because the latter was released inside the 7 day cooldown window.
- Set `permissions: {}` at the workflow level and granted `contents: read` to each job, so the default token holds only what each job needs.
- Added `persist-credentials: false` to all checkout steps, since no job pushes.
- Suppressed zizmor's `cache-poisoning` warnings on the `setup-ruby` bundler cache with inline comments. The cache uses default branch-isolated keys and feeds test runs, not release artifacts.

Both `zizmor .` (default and pedantic personas) and `actionlint` report no findings on the result.